### PR TITLE
Record original state tweaks

### DIFF
--- a/src/main/java/gopher/gui/analysisPane/vpanalysis.fxml
+++ b/src/main/java/gopher/gui/analysisPane/vpanalysis.fxml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.control.*?>
+<?import javafx.scene.control.SplitPane?>
+<?import javafx.scene.control.TableColumn?>
+<?import javafx.scene.control.TableView?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.web.WebView?>
+
 <StackPane xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1" fx:controller="gopher.gui.analysisPane.VPAnalysisPresenter">
     <SplitPane dividerPositions="0.5" orientation="VERTICAL">
         <VBox alignment="CENTER">
@@ -12,16 +15,17 @@
 
         <TableView fx:id="viewPointTableView" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308">
             <columns>
-                <TableColumn fx:id="actionTableColumn" editable="false" maxWidth="110.0" minWidth="110.0" prefWidth="110.0" resizable="false" text="Viewpoint" />
-                <TableColumn fx:id="deleteTableColumn" maxWidth="80.0" minWidth="80.0" resizable="false" text="Delete" />
+                <TableColumn fx:id="actionTableColumn" editable="false" maxWidth="110.0" minWidth="90.0" prefWidth="90.0" resizable="false" text="Viewpoint" />
                 <TableColumn fx:id="targetTableColumn" editable="false" maxWidth="100.0" minWidth="80.0" prefWidth="-1.0" text="Target" />
-                <TableColumn fx:id="genomicLocationColumn" editable="false" maxWidth="1.7976931348623157E308" minWidth="200.0" prefWidth="-1.0" text="Genomic location" />
+                <TableColumn fx:id="genomicLocationColumn" editable="false" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="150.0" text="Genomic location" />
                 <TableColumn fx:id="nSelectedTableColumn" maxWidth="1.7976931348623157E308" minWidth="110.0" prefWidth="-1.0" text="# Selected" />
                 <TableColumn fx:id="viewpointScoreColumn" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="-1.0" text="Score" />
                 <TableColumn fx:id="viewpointTotalLengthOfActiveSegments" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="-1.0" text="Active length" />
-                <TableColumn fx:id="viewpointTotalLength" maxWidth="1.7976931348623157E308" minWidth="120.0" prefWidth="-1.0" text="Total length" />
+                <TableColumn fx:id="viewpointTotalLength" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="-1.0" text="Total length" />
                 <TableColumn fx:id="fragmentOverlappingTSSColumn" maxWidth="1.7976931348623157E308" minWidth="120.0" prefWidth="-1.0" text="Fragment at TSS" />
             <TableColumn fx:id="manuallyRevisedColumn" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="-1.0" text="Manually revised" />
+                <TableColumn fx:id="deleteTableColumn" maxWidth="80.0" minWidth="80.0" resizable="false" text="Delete" />
+            <TableColumn fx:id="resetTableColumn" minWidth="75.0" prefWidth="75.0" text="Reset" />
             </columns>
          <columnResizePolicy>
             <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />

--- a/src/main/java/gopher/gui/gophermain/gophermain.fxml
+++ b/src/main/java/gopher/gui/gophermain/gophermain.fxml
@@ -193,7 +193,7 @@
                                     <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
                                 </GridPane.margin>
                             </Button>
-                            <Button fx:id="downloadAlignabilityMapButton" mnemonicParsing="false" onAction="#downloadAlignabilityMap" prefHeight="30.0" prefWidth="145.0" styleClass="Button" stylesheets="@gophermain.css" text="Download" GridPane.columnIndex="1" GridPane.rowIndex="6">
+                            <Button mnemonicParsing="false" onAction="#downloadAlignabilityMap" prefHeight="30.0" prefWidth="145.0" styleClass="Button" stylesheets="@gophermain.css" text="Download" GridPane.columnIndex="1" GridPane.rowIndex="6">
                                 <GridPane.margin>
                                     <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
                                 </GridPane.margin>

--- a/src/main/java/gopher/gui/help/help.fxml
+++ b/src/main/java/gopher/gui/help/help.fxml
@@ -4,9 +4,12 @@
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.web.WebView?>
-<AnchorPane xmlns="http://javafx.com/javafx/8.0.121" xmlns:fx="http://javafx.com/fxml/1" fx:controller="gopher.gui.help.HelpPresenter">
-   <children>
-       <WebView fx:id="wview" minHeight="-Infinity" minWidth="-Infinity" prefHeight="800.0" prefWidth="600.0" AnchorPane.bottomAnchor="40.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
-       <Button fx:id="closebutton" alignment="CENTER" defaultButton="true" layoutX="514.0" layoutY="771.0" minWidth="120.0" mnemonicParsing="false" onAction="#closeWindow" text="Close" AnchorPane.bottomAnchor="5.0" AnchorPane.rightAnchor="5.0" />
-   </children>
+<AnchorPane xmlns="http://javafx.com/javafx/8.0.121" xmlns:fx="http://javafx.com/fxml/1"
+            fx:controller="gopher.gui.help.HelpPresenter">
+    <WebView fx:id="wview" minHeight="-Infinity" minWidth="-Infinity" prefHeight="800.0" prefWidth="600.0"
+             AnchorPane.bottomAnchor="40.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0"
+             AnchorPane.topAnchor="0.0"/>
+    <Button alignment="CENTER" defaultButton="true" layoutX="514.0" layoutY="771.0" minWidth="120.0"
+            mnemonicParsing="false" onAction="#closeWindow" text="Close" AnchorPane.bottomAnchor="5.0"
+            AnchorPane.rightAnchor="5.0"/>
 </AnchorPane>

--- a/src/main/java/gopher/gui/settings/settings.fxml
+++ b/src/main/java/gopher/gui/settings/settings.fxml
@@ -6,9 +6,9 @@
 <?import javafx.scene.web.WebView?>
 <VBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" xmlns="http://javafx.com/javafx/8.0.121" xmlns:fx="http://javafx.com/fxml/1" fx:controller="gopher.gui.settings.SettingsPresenter">
     <WebView fx:id="wview" prefHeight="400.0" prefWidth="700.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" VBox.vgrow="ALWAYS" />
-    <HBox fx:id="okParent" alignment="CENTER" VBox.vgrow="NEVER">
+    <HBox  alignment="CENTER" VBox.vgrow="NEVER">
         <Region maxHeight="40.0" maxWidth="1.7976931348623157E308" HBox.hgrow="ALWAYS" />
-        <Button fx:id="okButton" defaultButton="true" minWidth="120.0" mnemonicParsing="false" onAction="#okButtonClicked" text="Ok" HBox.hgrow="NEVER">
+        <Button defaultButton="true" minWidth="120.0" mnemonicParsing="false" onAction="#okButtonClicked" text="Ok" HBox.hgrow="NEVER">
             <HBox.margin>
                 <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
             </HBox.margin>

--- a/src/main/java/gopher/gui/taskprogressbar/taskprogressbar.fxml
+++ b/src/main/java/gopher/gui/taskprogressbar/taskprogressbar.fxml
@@ -17,19 +17,17 @@
             </HBox.margin>
             </Label>
         </HBox>
-      <VBox>
-         <children>
-               <ProgressBar fx:id="vpProgressBar" maxWidth="1.7976931348623157E308" prefWidth="200.0" progress="0.0">
-               <VBox.margin>
-                  <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-               </VBox.margin>
-            </ProgressBar>
-               <Label fx:id="currentVPlabel">
-               <VBox.margin>
-                  <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-               </VBox.margin>
-            </Label>
-         </children>
-      </VBox>
+        <VBox>
+            <ProgressBar fx:id="vpProgressBar" maxWidth="1.7976931348623157E308" prefWidth="200.0" progress="0.0">
+                <VBox.margin>
+                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0"/>
+                </VBox.margin>
+         </ProgressBar>
+            <Label fx:id="currentVPlabel">
+                <VBox.margin>
+                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0"/>
+                </VBox.margin>
+         </Label>
+        </VBox>
     </VBox>
 </AnchorPane>

--- a/src/main/java/gopher/gui/viewpointpanel/ViewPointPresenter.java
+++ b/src/main/java/gopher/gui/viewpointpanel/ViewPointPresenter.java
@@ -250,6 +250,7 @@ public class ViewPointPresenter implements Initializable {
         isSelectedTableColumn.setCellValueFactory(cdf -> {
             // if we get here, the user has selected or deselected the checkbox
             this.viewpoint.setManuallyRevised();
+            this.analysisPresenter.refreshVPTable();
             Segment segment = cdf.getValue().getSegment();
             CheckBox checkBox = cdf.getValue().getCheckBox();
             if (segment.isSelected()) // inspect state of the segment and initialize CheckBox state accordingly

--- a/src/main/java/gopher/gui/viewpointpanel/ViewPointPresenter.java
+++ b/src/main/java/gopher/gui/viewpointpanel/ViewPointPresenter.java
@@ -249,7 +249,7 @@ public class ViewPointPresenter implements Initializable {
         colorTableColumn.setCellValueFactory(cdf -> new ReadOnlyStringWrapper(cdf.getValue().getColor()));
         isSelectedTableColumn.setCellValueFactory(cdf -> {
             // if we get here, the user has selected or deselected the checkbox
-            this.viewpoint.setManuallyRevised();
+            //this.viewpoint.setManuallyRevised();
             this.analysisPresenter.refreshVPTable();
             Segment segment = cdf.getValue().getSegment();
             CheckBox checkBox = cdf.getValue().getCheckBox();
@@ -411,10 +411,10 @@ public class ViewPointPresenter implements Initializable {
      * Calling this method sets the "manually revised" flag of the selected ViewPoint to
      * true and also refreshes the viewpoint table so that a check is shown.
      */
-    private void setManuallyRevised() {
+    /*private void setManuallyRevised() {
         this.viewpoint.setManuallyRevised();
         Platform.runLater( () -> this.analysisPresenter.refreshVPTable() );
-    }
+    }*/
 
 
 
@@ -529,7 +529,7 @@ public class ViewPointPresenter implements Initializable {
     private void zoom(double factor) {
         //String path=this.model.getGenomeFastaFile();
         logger.trace(String.format("Zooming with factor %.2f",factor));
-        this.viewpoint.setManuallyRevised();
+        //this.viewpoint.setManuallyRevised();
         logger.trace(String.format("Before zoom start=%d end =%d",viewpoint.getStartPos(),viewpoint.getEndPos() ));
         this.viewpoint.zoom(factor);
         logger.trace(String.format("After zoom start=%d end =%d",viewpoint.getStartPos(),viewpoint.getEndPos() ));

--- a/src/main/java/gopher/model/viewpoint/Segment.java
+++ b/src/main/java/gopher/model/viewpoint/Segment.java
@@ -491,7 +491,7 @@ public class Segment implements Serializable {
 
 
 
-    public List<Bait> setUsableBaitsForDownstreamMargin(Integer bmax, Integer baitSize, AlignabilityMap alignabilityMap,  Double minGCcontent, Double maxGCcontent, Double maxAlignabilityScore) {
+    private List<Bait> setUsableBaitsForDownstreamMargin(Integer bmax, Integer baitSize, AlignabilityMap alignabilityMap,  Double minGCcontent, Double maxGCcontent, Double maxAlignabilityScore) {
 
 
             Integer sta = this.getEndPos() - marginSize + 1;
@@ -533,7 +533,7 @@ public class Segment implements Serializable {
         Integer numOfRedundantBaitsRemoved = 0;
 
         // put the the coordinates of all upstream baits in a string Set
-        Set<String> upstreamCoordSet = new HashSet();
+        Set<String> upstreamCoordSet = new HashSet<>();
         for(Bait b : baitListUpStreamMargin) {
                 upstreamCoordSet.add(b.getRefId() + b.getStartPos());
         }
@@ -597,6 +597,11 @@ public class Segment implements Serializable {
         return meanRepeatContentOfBaits/this.getBaitNumTotal();
     }
 
+
+    @Override
+    public String toString() {
+        return String.format("%d-%d %s",getStartPos(),getEndPos(),isSelected()?"selected":"not selected");
+    }
 
 
 }

--- a/src/main/java/gopher/model/viewpoint/Segment.java
+++ b/src/main/java/gopher/model/viewpoint/Segment.java
@@ -147,6 +147,10 @@ public class Segment implements Serializable {
         }
     }
 
+    public boolean wasOriginallySelected() {
+        return this.originallySelected;
+    }
+
     /** @return true, if the Segment is selected, otherwise false. */
     public boolean isSelected() {
         return selected;

--- a/src/main/java/gopher/model/viewpoint/SimpleViewPointCreationTask.java
+++ b/src/main/java/gopher/model/viewpoint/SimpleViewPointCreationTask.java
@@ -16,6 +16,7 @@ import java.lang.instrument.Instrumentation;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 
 /**
@@ -30,7 +31,7 @@ public class SimpleViewPointCreationTask extends ViewPointCreationTask {
     /** Index of current viewpoint */
     private int i;
 
-    private AlignabilityMap alignabilityMap = null;
+    private AlignabilityMap alignabilityMap;
 
 
   /**
@@ -120,14 +121,13 @@ public class SimpleViewPointCreationTask extends ViewPointCreationTask {
         // estimate average size of restriction fragments
         // TODO: Move this code to a function getEstAvgRestFragLen
         logger.trace("Estimating the average length of restriction fragments from at least 100,000 fragments...");
-        // Combine all patterns in one regular expression.
-        String regExCombinedCutPat ="";
-        for(int i=0; i < model.getChosenEnzymelist().size(); i++) {
-            regExCombinedCutPat +=  model.getChosenEnzymelist().get(i).getPlainSite();
-            if(i<model.getChosenEnzymelist().size()-1) {
-                regExCombinedCutPat += "|";
-            }
-        }
+        // Combine all patterns into one regular expression.
+        String regExCombinedCutPat = model.getChosenEnzymelist().
+                stream().
+                map(RestrictionEnzyme::getPlainSite).
+                collect(Collectors.joining("|"));
+
+
         // count all occurrences of the cutting motifs and divide by sequence length
         int totalNumOfCuts = 0;
         long totalLength = 0;

--- a/src/main/java/gopher/model/viewpoint/ViewPoint.java
+++ b/src/main/java/gopher/model/viewpoint/ViewPoint.java
@@ -92,14 +92,14 @@ public class ViewPoint implements Serializable {
 //    private AlignabilityMap alignabilityMap = null;
     /** This is the unicode character for a checkmark. We will use it to show that the user has
      * checked this viewpoint. */
-    private static final String CHECK_MARK="\u2714";
+    //private static final String CHECK_MARK="\u2714";
     /** We will use the empty string to show that the user has not yet manually revised or saved this viewpoint.*/
-    private static final String EMPTY_STRING="";
+    //private static final String EMPTY_STRING="";
 
     /** This flag is set to true of the user has manually changed anything in the viewpoint (even if the
      * user has changed back to the original state -- this indicates that the user has worked on this viewpoiunt
      */
-    private String manuallyRevised=EMPTY_STRING;
+    //private String manuallyRevised=EMPTY_STRING;
     /** @return true iff the user has revised of modified this viewpoint in any way. */
     //public boolean wasManuallyRevised() {  return manuallyRevised.equals(CHECK_MARK);  }
 
@@ -139,8 +139,12 @@ public class ViewPoint implements Serializable {
         }
     }
 
+
     /** This function is called if the user has worked on this viewpoint at all. */
+    /*
     public void setManuallyRevised() {  this.manuallyRevised=CHECK_MARK;  }
+    */
+
     /**
      * Gets a list of all active (chosen) {@link Segment} objects.
      * @return a list of Segments of a viewpoint that are active and will be displayed on the UCSC Browser. */
@@ -975,6 +979,19 @@ public class ViewPoint implements Serializable {
         }
         // if no modified segment was found return false
         return false;
+    }
+
+    /**
+     * This fuction can be used to reset the set of segments to the original state
+     */
+    public void resetSegmentsToOriginalState() {
+        for(Segment s : this.restrictionSegmentList) {
+            if(s.wasOriginallySelected()) {
+                s.setSelected(true,false);
+            } else {
+                s.setSelected(false, false);
+            }
+        }
     }
 
 

--- a/src/main/java/gopher/model/viewpoint/ViewPoint.java
+++ b/src/main/java/gopher/model/viewpoint/ViewPoint.java
@@ -101,7 +101,7 @@ public class ViewPoint implements Serializable {
      */
     private String manuallyRevised=EMPTY_STRING;
     /** @return true iff the user has revised of modified this viewpoint in any way. */
-    public boolean wasManuallyRevised() {  return manuallyRevised.equals(CHECK_MARK);  }
+    //public boolean wasManuallyRevised() {  return manuallyRevised.equals(CHECK_MARK);  }
 
     void setPromoterNumber(int n, int total) { promoterNumber=n; totalPromoters=total;}
 
@@ -132,7 +132,11 @@ public class ViewPoint implements Serializable {
     }
 
     public String getManuallyRevised() {
-        return manuallyRevised;
+        if(this.wasModified()) {
+            return "\u2714"; // unicode character for a checkmark
+        } else {
+          return "";
+        }
     }
 
     /** This function is called if the user has worked on this viewpoint at all. */
@@ -955,6 +959,22 @@ public class ViewPoint implements Serializable {
         public ViewPoint build() {
             return new ViewPoint(this);
         }
+    }
+
+    /**
+     * This function can be used in order to determine if the set of selected segments has changed after creation
+     * of the viewpoint.
+     */
+    public boolean wasModified() {
+        // iterate over all segments (selected and deselected)
+        for(Segment s : this.restrictionSegmentList) {
+            if(s.wasOriginallySelected() != s.isSelected()) {
+                // return true for at the first modified segment found
+                return true;
+            }
+        }
+        // if no modified segment was found return false
+        return false;
     }
 
 


### PR DESCRIPTION
The setting of check marks now works as intended.

The only thing that is missing is a reset button in the analysis tab. I have already added the function `public void resetSegmentsToOriginalState()` to the class viewpoints. The button could be placed next to the _Mnaually revised_ column. On this occasion, it might be it is a good idea to move the _Delete_ button to the right of the column (#176). 

![image](https://user-images.githubusercontent.com/10495485/42691027-c6ea2c9c-86a6-11e8-9f40-fb5ecec3f98a.png)
![image](https://user-images.githubusercontent.com/10495485/42691119-0f09d720-86a7-11e8-943a-9ec3d9bdde84.png)

 @ielis I'm not that good in Java FX. Could you add (move) the buttons? 