### PR TITLE
Windows executable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,6 +264,49 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <groupId>com.akathist.maven.plugins.launch4j</groupId>
+                <artifactId>launch4j-maven-plugin</artifactId>
+                <version>1.7.22</version>
+                <executions>
+                    <execution>
+                        <id>l4j-clui</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>launch4j</goal>
+                        </goals>
+                        <configuration>
+                            <headerType>gui</headerType>
+                            <jar>target/${project.build.finalName}-jar-with-dependencies.jar</jar>
+                            <outfile>target/${project.build.finalName}.exe</outfile>
+                            <downloadUrl>http://java.com/download</downloadUrl>
+                            <classPath>
+                                <mainClass>gopher.Gopher</mainClass>
+                            </classPath>
+                            <jre>
+                                <bundledJre64Bit>false</bundledJre64Bit>
+                                <bundledJreAsFallback>false</bundledJreAsFallback>
+                                <minVersion>1.8.0</minVersion>
+                                <jdkPreference>preferJre</jdkPreference>
+                                <runtimeBits>64</runtimeBits>
+                                <initialHeapSize>5120</initialHeapSize> <!--5GB - TODO - reconsider-->
+                                <maxHeapSize>8192</maxHeapSize> <!--8GB - TODO - reconsider-->
+                            </jre>
+                            <versionInfo>
+                                <fileVersion>1.0.0.0</fileVersion>
+                                <txtFileVersion>${project.version}</txtFileVersion>
+                                <fileDescription>${project.name}</fileDescription>
+                                <copyright>C</copyright>
+                                <productVersion>1.0.0.0</productVersion>
+                                <txtProductVersion>1.0.0.0</txtProductVersion>
+                                <productName>${project.name}</productName>
+                                <internalName>InternalGopher</internalName>
+                                <originalFilename>${project.build.finalName}.exe</originalFilename>
+                            </versionInfo>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,4 +1,4 @@
-log4j.rootLogger=trace, stdout, logfile
+log4j.rootLogger=trace, stdout, file
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
@@ -6,12 +6,12 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 # Pattern to output the caller's file name and line number.
 log4j.appender.stdout.layout.ConversionPattern=[%p] %d{MM-dd-yyyy HH:mm:ss} [%t] (%F:%L) - %m%n
 
-log4j.appender.logfile=org.apache.log4j.RollingFileAppender
-log4j.appender.logfile.File=gopher.log
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file.File=gopher.log
 
-log4j.appender.logfile.MaxFileSize=100KB
+log4j.appender.file.MaxFileSize=100KB
 # Keep two backup files
-log4j.appender.logfile.MaxBackupIndex=2
+log4j.appender.file.MaxBackupIndex=2
 
-log4j.appender.logfile.layout=org.apache.log4j.PatternLayout
-log4j.appender.logfile.layout.ConversionPattern=[%p] [%d{MM-dd-yyyy HH:mm:ss}] (%F:%L) - %m%n
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=[%p] [%d{MM-dd-yyyy HH:mm:ss}] (%F:%L) - %m%n


### PR DESCRIPTION
Hi Peter, Peter
here I am adding a Maven plugin that will create an EXE wrapper for Windows users. User will be prompted to download Java if it is not installed.
When launching in Windows *initial* JVM heap size will be set to 5GB and *max* heap size will be 8GB.

I also made minor changes to `log4j.properties` because log file was not being populated with entries.