### PR TITLE
View ucsc image

### DIFF
--- a/src/main/java/gopher/gui/analysisPane/vpanalysis.fxml
+++ b/src/main/java/gopher/gui/analysisPane/vpanalysis.fxml
@@ -2,41 +2,48 @@
 
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ListView?>
+<?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.control.TableColumn?>
 <?import javafx.scene.control.TableView?>
-<?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
-<AnchorPane xmlns="http://javafx.com/javafx/8.0.111" xmlns:fx="http://javafx.com/fxml/1" fx:controller="gopher.gui.analysisPane.VPAnalysisPresenter">
-   <children>
-        <VBox alignment="TOP_CENTER" maxWidth="-Infinity" minHeight="61.0" prefHeight="61.0" prefWidth="1105.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-         <HBox alignment="CENTER" prefHeight="40.0" prefWidth="1105.0">
-               <Label styleClass="toplabel" stylesheets="@vpanalysis.css" text="Panel design summary" />
-         </HBox>
-         <HBox fx:id="listviewHbox" prefHeight="120.0" prefWidth="1105.0">
-               <ListView fx:id="lviewKey" minHeight="175.0" prefHeight="170.0" prefWidth="200.0" />
-               <ListView fx:id="lviewValue" minHeight="175.0" prefHeight="170.0" prefWidth="905.0" />
-         </HBox>
-        </VBox>
-
-              <TableView fx:id="viewPointTableView" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="500.0" prefWidth="1105.0" stylesheets="@vpanalysis.css" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="200.0">
-            <columns>
-                <TableColumn fx:id="actionTableColumn" editable="false" maxWidth="110.0" minWidth="90.0" prefWidth="90.0" resizable="false" text="Viewpoint" />
-                <TableColumn fx:id="targetTableColumn" editable="false" maxWidth="100.0" minWidth="80.0" prefWidth="-1.0" text="Target" />
-                <TableColumn fx:id="genomicLocationColumn" editable="false" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="150.0" text="Genomic location" />
-                <TableColumn fx:id="nSelectedTableColumn" maxWidth="1.7976931348623157E308" minWidth="110.0" prefWidth="-1.0" text="# Selected" />
-                <TableColumn fx:id="viewpointScoreColumn" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="-1.0" text="Score" />
-                <TableColumn fx:id="viewpointTotalLengthOfActiveSegments" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="-1.0" text="Active length" />
-                <TableColumn fx:id="viewpointTotalLength" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="-1.0" text="Total length" />
-                <TableColumn fx:id="fragmentOverlappingTSSColumn" maxWidth="1.7976931348623157E308" minWidth="120.0" prefWidth="-1.0" text="Fragment at TSS" />
-            <TableColumn fx:id="manuallyRevisedColumn" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="-1.0" text="Manually revised" />
-                <TableColumn fx:id="deleteTableColumn" maxWidth="80.0" minWidth="80.0" resizable="false" text="Delete" />
-            <TableColumn fx:id="resetTableColumn" minWidth="75.0" prefWidth="75.0" text="Reset" />
-            </columns>
-         <columnResizePolicy>
-            <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
-         </columnResizePolicy>
-        </TableView>
-   </children>
-</AnchorPane>
+<ScrollPane fitToHeight="true" fitToWidth="true" xmlns="http://javafx.com/javafx/8.0.121" xmlns:fx="http://javafx.com/fxml/1" fx:controller="gopher.gui.analysisPane.VPAnalysisPresenter">
+   <content>
+      <StackPane alignment="TOP_CENTER">
+         <children>
+            <VBox alignment="TOP_CENTER" maxWidth="1200.0" minHeight="600.0" minWidth="1105.0" prefWidth="1200.0">
+               <children>
+                    <VBox alignment="TOP_CENTER">
+                        <Label styleClass="toplabel" stylesheets="@vpanalysis.css" text="Panel design summary" />
+                     <HBox fx:id="listviewHbox" alignment="TOP_CENTER" prefHeight="120.0" prefWidth="1105.0">
+                           <ListView fx:id="lviewKey" minHeight="175.0" prefHeight="170.0" prefWidth="200.0" />
+                           <ListView fx:id="lviewValue" minHeight="175.0" prefHeight="170.0" prefWidth="905.0" />
+                     </HBox>
+                    </VBox>
+            
+                                <TableView fx:id="viewPointTableView" stylesheets="@vpanalysis.css" VBox.vgrow="ALWAYS">
+                        <columns>
+                            <TableColumn fx:id="actionTableColumn" editable="false" maxWidth="105.0" minWidth="105.0" prefWidth="105.0" resizable="false" text="Viewpoint" />
+                            <TableColumn fx:id="targetTableColumn" editable="false" maxWidth="100.0" minWidth="80.0" prefWidth="-1.0" text="Target" />
+                            <TableColumn fx:id="genomicLocationColumn" editable="false" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="150.0" text="Genomic location" />
+                            <TableColumn fx:id="nSelectedTableColumn" maxWidth="1.7976931348623157E308" minWidth="110.0" prefWidth="-1.0" text="# Selected" />
+                            <TableColumn fx:id="viewpointScoreColumn" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="-1.0" text="Score" />
+                            <TableColumn fx:id="viewpointTotalLengthOfActiveSegments" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="-1.0" text="Active length" />
+                            <TableColumn fx:id="viewpointTotalLength" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="-1.0" text="Total length" />
+                            <TableColumn fx:id="fragmentOverlappingTSSColumn" maxWidth="1.7976931348623157E308" minWidth="120.0" prefWidth="-1.0" text="Fragment at TSS" />
+                        <TableColumn fx:id="manuallyRevisedColumn" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="-1.0" text="Manually revised" />
+                            <TableColumn fx:id="deleteTableColumn" maxWidth="80.0" minWidth="80.0" resizable="false" text="Delete" />
+                        <TableColumn fx:id="resetTableColumn" maxWidth="100.0" minWidth="100.0" prefWidth="100.0" text="Reset" />
+                        </columns>
+                     <columnResizePolicy>
+                        <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
+                     </columnResizePolicy>
+                    </TableView>
+               </children>
+            </VBox>
+         </children>
+      </StackPane>
+   </content>
+</ScrollPane>

--- a/src/main/java/gopher/gui/gophermain/gophermain.fxml
+++ b/src/main/java/gopher/gui/gophermain/gophermain.fxml
@@ -1,448 +1,406 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.CheckBox?>
-<?import javafx.scene.control.ChoiceBox?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.Menu?>
-<?import javafx.scene.control.MenuBar?>
-<?import javafx.scene.control.MenuItem?>
-<?import javafx.scene.control.ProgressIndicator?>
-<?import javafx.scene.control.RadioMenuItem?>
-<?import javafx.scene.control.ScrollPane?>
-<?import javafx.scene.control.Separator?>
-<?import javafx.scene.control.SeparatorMenuItem?>
-<?import javafx.scene.control.Tab?>
-<?import javafx.scene.control.TabPane?>
-<?import javafx.scene.control.TextField?>
-<?import javafx.scene.control.Tooltip?>
+<?import javafx.geometry.*?>
+<?import javafx.scene.control.*?>
 <?import javafx.scene.effect.DropShadow?>
-<?import javafx.scene.layout.BorderPane?>
-<?import javafx.scene.layout.ColumnConstraints?>
-<?import javafx.scene.layout.GridPane?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.Region?>
-<?import javafx.scene.layout.RowConstraints?>
-<?import javafx.scene.layout.StackPane?>
-<?import javafx.scene.layout.VBox?>
-
-<ScrollPane fitToHeight="true" fitToWidth="true" xmlns="http://javafx.com/javafx/8.0.111" xmlns:fx="http://javafx.com/fxml/1" fx:controller="gopher.gui.gophermain.GopherMainPresenter">
-    <BorderPane fx:id="rootNode" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="677.0" minWidth="830.0" stylesheets="@gophermain.css">
-        <top>
-            <HBox maxWidth="1.7976931348623157E308" BorderPane.alignment="CENTER">
-                <MenuBar HBox.hgrow="NEVER">
-                    <Menu mnemonicParsing="false" text="File">
-                        <MenuItem accelerator="Shortcut+N" mnemonicParsing="false" onAction="#startNewProject" text="New" />
-                        <MenuItem accelerator="Shortcut+S" mnemonicParsing="false" onAction="#saveProject" text="Save project" />
-                        <MenuItem mnemonicParsing="false" onAction="#importProject" text="Import project ..." />
-                        <MenuItem mnemonicParsing="false" onAction="#exportProject" text="Export project ..." />
-                        <MenuItem mnemonicParsing="false" onAction="#saveProjectAndClose" text="Save project and close" />
-                        <MenuItem accelerator="Shortcut+Q" mnemonicParsing="false" onAction="#closeWindow" text="Quit" />
-                    </Menu>
-                    <Menu mnemonicParsing="false" text="Edit">
-                        <MenuItem mnemonicParsing="false" onAction="#showSettingsOfCurrentProject" text="Show settings of current project" />
-                        <MenuItem mnemonicParsing="false" onAction="#setProxyDialog" text="Set proxy" />
-                        <MenuItem mnemonicParsing="false" onAction="#deleteProjectFiles" text="Delete project files ..." />
-                    </Menu>
-                    <Menu mnemonicParsing="false" text="Export">
-                        <MenuItem mnemonicParsing="false" onAction="#displayReport" text="Display report" />
-                        <MenuItem mnemonicParsing="false" onAction="#exportReport" text="Export report" />
-                  <SeparatorMenuItem mnemonicParsing="false" />
-                        <MenuItem mnemonicParsing="false" onAction="#exportBEDFiles" text="Save BED files as ..." />
-                        <MenuItem mnemonicParsing="false" onAction="#saveDigestFileAs" text="Save digest file as ..." />
-                        <MenuItem mnemonicParsing="false" onAction="#saveProbeFileAs" text="Save probe file as ..." />
-                    </Menu>
-                </MenuBar>
-                <Region maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" styleClass="menu-bar" HBox.hgrow="ALWAYS" />
-                <MenuBar nodeOrientation="RIGHT_TO_LEFT" HBox.hgrow="NEVER">
-                    <Menu mnemonicParsing="false" text="Help">
-                        <MenuItem accelerator="Shortcut+H" mnemonicParsing="false" onAction="#showHelpWindow" text="Help" />
-                        <Menu mnemonicParsing="false" text="Example gene sets">
-                            <MenuItem mnemonicParsing="false" onAction="#openGeneWindowWithExampleHumanGenes" text="human" />
-                            <MenuItem mnemonicParsing="false" onAction="#openGeneWindowWithExampleMouseGenes" text="mouse" />
-                        </Menu>
-                        <MenuItem mnemonicParsing="false" onAction="#showLog" text="Show log" />
-                        <Menu mnemonicParsing="false" text="Set logging level">
-                            <RadioMenuItem fx:id="loggingLevelOFF" mnemonicParsing="false" text="OFF" />
-                            <RadioMenuItem fx:id="loggingLevelTrace" mnemonicParsing="false" text="TRACE" />
-                            <RadioMenuItem fx:id="loggingLevelInfo" mnemonicParsing="false" text="INFO" />
-                            <RadioMenuItem fx:id="loggingLevelDebug" mnemonicParsing="false" text="DEBUG" />
-                            <RadioMenuItem fx:id="loggingLevelWarn" mnemonicParsing="false" text="WARN" />
-                            <RadioMenuItem fx:id="loggingLevelError" mnemonicParsing="false" text="ERROR" />
-                        </Menu>
-                        <MenuItem mnemonicParsing="false" onAction="#about" text="About" />
-                    </Menu>
-                </MenuBar>
-            </HBox>
-        </top>
-        <center>
-            <TabPane fx:id="tabpane" tabMaxHeight="30.0" tabMaxWidth="200.0" BorderPane.alignment="CENTER">
-                <Tab id="setuptab" closable="false" text="Set up">
-                    <VBox alignment="TOP_CENTER" fillWidth="false">
-                        <effect>
-                            <DropShadow color="#00000097" height="4.00" radius="2.0" spread="0.25" width="5.0" />
-                        </effect>
-                        <GridPane minWidth="800.0" prefHeight="200.0" prefWidth="832.0" styleClass="grid" VBox.vgrow="NEVER">
-                            <columnConstraints>
-                                <ColumnConstraints halignment="LEFT" hgrow="NEVER" minWidth="200.0" prefWidth="200.0" />
-                                <ColumnConstraints halignment="LEFT" hgrow="NEVER" minWidth="160.0" prefWidth="160.0" />
-                                <ColumnConstraints hgrow="NEVER" maxWidth="50.0" minWidth="50.0" prefWidth="50.0" />
-                                <ColumnConstraints hgrow="ALWAYS" maxWidth="420.0" minWidth="180.0" />
-                        <ColumnConstraints hgrow="ALWAYS" maxWidth="420.0" minWidth="160.0" prefWidth="100.0" />
-                        <ColumnConstraints hgrow="ALWAYS" maxWidth="420.0" minWidth="50.0" prefWidth="50.0" />
-                            </columnConstraints>
-                            <rowConstraints>
-                        <RowConstraints minHeight="50.0" prefHeight="30.0" />
-                                <RowConstraints minHeight="50.0" />
-                                <RowConstraints minHeight="50.0" />
-                                <RowConstraints minHeight="50.0" />
-                            </rowConstraints>
-                            <VBox.margin>
-                                <Insets />
-                            </VBox.margin>
-                            <Label text="Genome build" GridPane.rowIndex="1">
-                                <GridPane.margin>
+<?import javafx.scene.layout.*?>
+<BorderPane fx:id="rootNode" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" stylesheets="@gophermain.css" xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1" fx:controller="gopher.gui.gophermain.GopherMainPresenter">
+     <top>
+         <HBox alignment="TOP_CENTER" BorderPane.alignment="CENTER">
+             <MenuBar minHeight="30.0" minWidth="183.0" HBox.hgrow="NEVER">
+                 <Menu mnemonicParsing="false" text="File">
+                     <MenuItem accelerator="Shortcut+N" mnemonicParsing="false" onAction="#startNewProject" text="New" />
+                     <MenuItem accelerator="Shortcut+S" mnemonicParsing="false" onAction="#saveProject" text="Save project" />
+                     <MenuItem mnemonicParsing="false" onAction="#importProject" text="Import project ..." />
+                     <MenuItem mnemonicParsing="false" onAction="#exportProject" text="Export project ..." />
+                     <MenuItem mnemonicParsing="false" onAction="#saveProjectAndClose" text="Save project and close" />
+                     <MenuItem accelerator="Shortcut+Q" mnemonicParsing="false" onAction="#closeWindow" text="Quit" />
+                 </Menu>
+                 <Menu mnemonicParsing="false" text="Edit">
+                     <MenuItem mnemonicParsing="false" onAction="#showSettingsOfCurrentProject" text="Show settings of current project" />
+                     <MenuItem mnemonicParsing="false" onAction="#setProxyDialog" text="Set proxy" />
+                     <MenuItem mnemonicParsing="false" onAction="#deleteProjectFiles" text="Delete project files ..." />
+                 </Menu>
+                 <Menu mnemonicParsing="false" text="Export">
+                     <MenuItem mnemonicParsing="false" onAction="#displayReport" text="Display report" />
+                     <MenuItem mnemonicParsing="false" onAction="#exportReport" text="Export report" />
+               <SeparatorMenuItem mnemonicParsing="false" />
+                     <MenuItem mnemonicParsing="false" onAction="#exportBEDFiles" text="Save BED files as ..." />
+                     <MenuItem mnemonicParsing="false" onAction="#saveDigestFileAs" text="Save digest file as ..." />
+                     <MenuItem mnemonicParsing="false" onAction="#saveProbeFileAs" text="Save probe file as ..." />
+                 </Menu>
+             </MenuBar>
+             <Region styleClass="menu-bar" HBox.hgrow="SOMETIMES" />
+             <MenuBar minHeight="30.0" minWidth="72.0" nodeOrientation="RIGHT_TO_LEFT" HBox.hgrow="NEVER">
+                 <Menu mnemonicParsing="false" text="Help">
+                     <MenuItem accelerator="Shortcut+H" mnemonicParsing="false" onAction="#showHelpWindow" text="Help" />
+                     <Menu mnemonicParsing="false" text="Example gene sets">
+                         <MenuItem mnemonicParsing="false" onAction="#openGeneWindowWithExampleHumanGenes" text="human" />
+                         <MenuItem mnemonicParsing="false" onAction="#openGeneWindowWithExampleMouseGenes" text="mouse" />
+                     </Menu>
+                     <MenuItem mnemonicParsing="false" onAction="#showLog" text="Show log" />
+                     <Menu mnemonicParsing="false" text="Set logging level">
+                         <RadioMenuItem fx:id="loggingLevelOFF" mnemonicParsing="false" text="OFF" />
+                         <RadioMenuItem fx:id="loggingLevelTrace" mnemonicParsing="false" text="TRACE" />
+                         <RadioMenuItem fx:id="loggingLevelInfo" mnemonicParsing="false" text="INFO" />
+                         <RadioMenuItem fx:id="loggingLevelDebug" mnemonicParsing="false" text="DEBUG" />
+                         <RadioMenuItem fx:id="loggingLevelWarn" mnemonicParsing="false" text="WARN" />
+                         <RadioMenuItem fx:id="loggingLevelError" mnemonicParsing="false" text="ERROR" />
+                     </Menu>
+                     <MenuItem mnemonicParsing="false" onAction="#about" text="About" />
+                 </Menu>
+             </MenuBar>
+         </HBox>
+     </top>
+     <center>
+         <TabPane fx:id="tabpane" tabMaxHeight="30.0" tabMaxWidth="200.0">
+             <Tab id="setuptab" closable="false" text="Set up">
+            <ScrollPane fitToHeight="true" fitToWidth="true">
+               <content>
+                  <StackPane alignment="TOP_CENTER">
+                     <children>
+                             <VBox alignment="TOP_CENTER" maxHeight="714.0" maxWidth="900.0" minHeight="714.0" minWidth="900.0" prefHeight="714.0" prefWidth="900.0">
+                                 <effect>
+                                     <DropShadow color="#00000097" height="4.00" radius="2.0" spread="0.25" width="5.0" />
+                                 </effect>
+                                 <GridPane styleClass="grid" VBox.vgrow="NEVER">
+                                     <columnConstraints>
+                                         <ColumnConstraints halignment="LEFT" hgrow="NEVER" minWidth="200.0" prefWidth="200.0" />
+                                         <ColumnConstraints halignment="LEFT" hgrow="NEVER" minWidth="160.0" prefWidth="160.0" />
+                                         <ColumnConstraints hgrow="NEVER" maxWidth="50.0" minWidth="50.0" prefWidth="50.0" />
+                                         <ColumnConstraints maxWidth="420.0" minWidth="180.0" />
+                                 <ColumnConstraints maxWidth="420.0" minWidth="160.0" prefWidth="100.0" />
+                                 <ColumnConstraints hgrow="ALWAYS" maxWidth="420.0" minWidth="50.0" prefWidth="50.0" />
+                                     </columnConstraints>
+                                     <rowConstraints>
+                                 <RowConstraints minHeight="50.0" />
+                                         <RowConstraints minHeight="50.0" />
+                                         <RowConstraints minHeight="50.0" />
+                                         <RowConstraints minHeight="50.0" />
+                                     </rowConstraints>
+                                     <VBox.margin>
+                                         <Insets />
+                                     </VBox.margin>
+                              <Separator prefWidth="200.0" styleClass="sep" stylesheets="@gophermain.css">
+                                 <GridPane.margin>
+                                    <Insets left="10.0" />
+                                 </GridPane.margin>
+                              </Separator>
+                                     <Label text="Genome build" GridPane.rowIndex="1">
+                                         <GridPane.margin>
+                                             <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+                                         </GridPane.margin>
+                                     </Label>
+                                     <Label text="Genome" GridPane.rowIndex="2">
+                                         <GridPane.margin>
+                                             <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+                                         </GridPane.margin>
+                                     </Label>
+                                     <Label text="Decompress genome" GridPane.rowIndex="3">
+                                         <GridPane.margin>
+                                             <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+                                         </GridPane.margin>
+                                     </Label>
+                                     <Label text="Index genome FASTA" GridPane.columnIndex="3" GridPane.rowIndex="1">
+                                         <GridPane.margin>
+                                             <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+                                         </GridPane.margin>
+                                     </Label>
+                                     <Label text="Transcripts" GridPane.columnIndex="3" GridPane.rowIndex="2">
+                                         <GridPane.margin>
+                                             <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+                                         </GridPane.margin>
+                                     </Label>
+                                     <Label text="Alignability map" GridPane.columnIndex="3" GridPane.rowIndex="3">
+                                         <GridPane.margin>
+                                             <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+                                         </GridPane.margin>
+                                     </Label>
+                              <Label styleClass="biglabel" stylesheets="@gophermain.css" text="Data sources" GridPane.columnIndex="1">
+                                 <padding>
+                                    <Insets left="10.0" />
+                                 </padding>
+                                 <GridPane.margin>
+                                    <Insets left="10.0" />
+                                 </GridPane.margin>
+                              </Label>
+                                     <ChoiceBox fx:id="genomeChoiceBox" prefHeight="30.0" prefWidth="145.0" stylesheets="@gophermain.css" GridPane.columnIndex="1" GridPane.rowIndex="1">
+                                         <GridPane.margin>
+                                             <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                         </GridPane.margin>
+                                     </ChoiceBox>
+                                     <Button fx:id="downloadGenomeButton" mnemonicParsing="false" onAction="#downloadGenome" prefHeight="30.0" prefWidth="145.0" styleClass="Button" stylesheets="@gophermain.css" text="Download" GridPane.columnIndex="1" GridPane.rowIndex="2">
+                                         <GridPane.margin>
+                                             <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                         </GridPane.margin>
+                                     </Button>
+                                     <Button fx:id="decompressGenomeButton" mnemonicParsing="false" onAction="#decompressGenome" prefHeight="30.0" prefWidth="145.0" styleClass="Button" stylesheets="@gophermain.css" text="Start" GridPane.columnIndex="1" GridPane.rowIndex="3">
+                                         <GridPane.margin>
+                                             <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                         </GridPane.margin>
+                                     </Button>
+                                     <Button fx:id="indexGenomeButton" mnemonicParsing="false" onAction="#indexGenome" prefHeight="30.0" prefWidth="145.0" styleClass="Button" stylesheets="@gophermain.css" text="Start" GridPane.columnIndex="4" GridPane.rowIndex="1">
+                                         <GridPane.margin>
+                                             <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                         </GridPane.margin>
+                                     </Button>
+                                     <Button fx:id="downloadTranscriptsButton" mnemonicParsing="false" onAction="#downloadRefGeneTranscripts" prefHeight="30.0" prefWidth="145.0" styleClass="Button" stylesheets="@gophermain.css" text="Download" GridPane.columnIndex="4" GridPane.rowIndex="2">
+                                         <GridPane.margin>
+                                             <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                         </GridPane.margin>
+                                     </Button>
+                                     <Button mnemonicParsing="false" onAction="#downloadAlignabilityMap" prefHeight="30.0" prefWidth="145.0" styleClass="Button" stylesheets="@gophermain.css" text="Download" GridPane.columnIndex="4" GridPane.rowIndex="3">
+                                         <GridPane.margin>
+                                             <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                         </GridPane.margin>
+                                     </Button>
+                                     <ProgressIndicator fx:id="genomeDownloadPI" progress="0.0" GridPane.columnIndex="2" GridPane.rowIndex="2" />
+                                     <ProgressIndicator fx:id="genomeDecompressPI" progress="0.0" GridPane.columnIndex="2" GridPane.rowIndex="3" />
+                                     <ProgressIndicator fx:id="genomeIndexPI" progress="0.0" GridPane.columnIndex="5" GridPane.rowIndex="1" />
+                                     <ProgressIndicator fx:id="transcriptDownloadPI" progress="0.0" GridPane.columnIndex="5" GridPane.rowIndex="2" />
+                                     <ProgressIndicator fx:id="alignabilityDownloadPI" progress="0.0" GridPane.columnIndex="5" GridPane.rowIndex="3" />
+                                 </GridPane>
+                           <GridPane styleClass="grid" VBox.vgrow="NEVER">
+                             <columnConstraints>
+                               <ColumnConstraints halignment="CENTER" minWidth="300.0" prefWidth="300.0" />
+                               <ColumnConstraints halignment="CENTER" minWidth="300.0" prefWidth="300.0" />
+                                 <ColumnConstraints halignment="CENTER" minWidth="300.0" prefWidth="300.0" />
+                             </columnConstraints>
+                             <rowConstraints>
+                               <RowConstraints minHeight="50.0" vgrow="NEVER" />
+                               <RowConstraints vgrow="NEVER" />
+                               <RowConstraints vgrow="NEVER" />
+                             </rowConstraints>
+                              <children>
+                                 <HBox alignment="CENTER_LEFT" GridPane.columnSpan="2147483647" GridPane.valignment="CENTER">
+                                    <children>
+                                               <Separator maxWidth="200.0" prefWidth="200.0" styleClass="sep" stylesheets="@gophermain.css" />
+                                               <Label styleClass="biglabel" stylesheets="@gophermain.css" text="Enrichment targets">
+                                                   <padding>
+                                                       <Insets left="10.0" />
+                                                   </padding>
+                                               </Label>
+                                    </children>
+                                 </HBox>
+                                          <Button mnemonicParsing="false" onAction="#enterGeneList" prefHeight="30.0" prefWidth="145.0" styleClass="Button" stylesheets="@gophermain.css" text="Target gene list" GridPane.rowIndex="1">
+                                    <GridPane.margin>
+                                       <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                    </GridPane.margin>
+                                 </Button>
+                                          <Label fx:id="targetGeneLabel" styleClass="bluelabel" stylesheets="@gophermain.css" GridPane.rowIndex="2" />
+                                          <Button mnemonicParsing="false" onAction="#allProteinCodingGenes" prefHeight="30.0" styleClass="Button" stylesheets="@gophermain.css" text="All protein-coding genes" GridPane.columnIndex="1" GridPane.rowIndex="1">
+                                    <GridPane.margin>
+                                       <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                    </GridPane.margin>
+                                 </Button>
+                                          <Label fx:id="allGenesLabel" styleClass="bluelabel" stylesheets="@gophermain.css" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                                          <Button mnemonicParsing="false" onAction="#enterBedFile" prefHeight="30.0" prefWidth="145.0" styleClass="Button" stylesheets="@gophermain.css" text="Enter BED file" GridPane.columnIndex="2" GridPane.rowIndex="1">
+                                    <GridPane.margin>
+                                       <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                    </GridPane.margin>
+                                 </Button>
+                                          <Label fx:id="bedTargetsLabel" styleClass="bluelabel" stylesheets="@gophermain.css" GridPane.columnIndex="2" GridPane.rowIndex="2" />
+                              </children>
+                           </GridPane>
+                                 <GridPane styleClass="grid" VBox.vgrow="NEVER">
+                                     <columnConstraints>
+                                         <ColumnConstraints halignment="LEFT" hgrow="NEVER" minWidth="200.0" prefWidth="200.0" />
+                                         <ColumnConstraints hgrow="SOMETIMES" minWidth="210.0" />
+                                         <ColumnConstraints hgrow="NEVER" minWidth="210.0" prefWidth="210.0" />
+                                         <ColumnConstraints hgrow="SOMETIMES" minWidth="210.0" />
+                                     </columnConstraints>
+                                     <rowConstraints>
+                                 <RowConstraints minHeight="40.0" prefHeight="30.0" />
+                                 <RowConstraints minHeight="40.0" prefHeight="30.0" />
+                                 <RowConstraints minHeight="40.0" prefHeight="30.0" />
+                                         <RowConstraints minHeight="40.0" />
+                                         <RowConstraints minHeight="40.0" />
+                                         <RowConstraints minHeight="40.0" />
+                                 <RowConstraints minHeight="40.0" />
+                                 <RowConstraints minHeight="40.0" prefHeight="30.0" />
+                                 <RowConstraints minHeight="40.0" prefHeight="30.0" />
+                                         <RowConstraints minHeight="45.0" />
+                                     </rowConstraints>
+                                     <Label fx:id="sizeUpLabel" text="Upstream size" GridPane.rowIndex="3">
+                                         <tooltip>
+                                             <Tooltip text="Number of nucleotides 5' of the target start position in which fragments will be sought" wrapText="true" />
+                                         </tooltip>
+                                         <GridPane.margin>
+                                             <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+                                         </GridPane.margin>
+                                     </Label>
+                                     <Label text="Minimum digest size" GridPane.rowIndex="4">
+                                         <tooltip>
+                                             <Tooltip text="Minimum size in nucleotides for a fragment to be selected" />
+                                         </tooltip>
+                                         <GridPane.margin>
+                                             <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+                                         </GridPane.margin>
+                                     </Label>
+                                     <Label text="Minimum GC content (%)" GridPane.rowIndex="5">
+                                         <tooltip>
+                                             <Tooltip text="Minimum percent GC content for a fragment to be selected" />
+                                         </tooltip>
+                                         <GridPane.margin>
+                                             <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+                                         </GridPane.margin>
+                                     </Label>
+                                     <TextField fx:id="sizeUpTextField" minHeight="30.0" promptText="1500" GridPane.columnIndex="1" GridPane.rowIndex="3">
+                                         <GridPane.margin>
+                                             <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                         </GridPane.margin>
+                                         <tooltip>
+                                             <Tooltip text="Range (5')  to search for fragments (only used in extended approach)" />
+                                         </tooltip>
+                                     </TextField>
+                                     <TextField fx:id="sizeDownTextField" minHeight="30.0" promptText="5000" GridPane.columnIndex="3" GridPane.rowIndex="3">
+                                         <GridPane.margin>
+                                             <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                         </GridPane.margin>
+                                         <tooltip>
+                                             <Tooltip text="Range (3') to search for fragments (only used in extended approach)" />
+                                         </tooltip>
+                                     </TextField>
+                                     <TextField fx:id="minFragSizeTextField" minHeight="30.0" promptText="130" GridPane.columnIndex="1" GridPane.rowIndex="4">
+                                         <GridPane.margin>
+                                             <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                         </GridPane.margin>
+                                     </TextField>
+                                     <TextField fx:id="maxKmerAlignabilityTextField" minHeight="30.0" promptText="10" GridPane.columnIndex="3" GridPane.rowIndex="4">
+                                         <GridPane.margin>
+                                             <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                         </GridPane.margin>
+                                     </TextField>
+                                     <TextField fx:id="minGCContentTextField" minHeight="30.0" GridPane.columnIndex="1" GridPane.rowIndex="5">
+                                         <GridPane.margin>
+                                             <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                         </GridPane.margin>
+                                     </TextField>
+                                     <TextField fx:id="maxGCContentTextField" minHeight="30.0" GridPane.columnIndex="3" GridPane.rowIndex="5">
+                                         <GridPane.margin>
+                                             <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                         </GridPane.margin>
+                                     </TextField>
+                                     <Label fx:id="sizeDownLabel" text="Downstream size" GridPane.columnIndex="2" GridPane.rowIndex="3">
+                                         <tooltip>
+                                             <Tooltip text="Number of nucleotides 3' of the target start position in which fragments will be sought" />
+                                         </tooltip>
+                                         <GridPane.margin>
+                                             <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                         </GridPane.margin>
+                                     </Label>
+                                     <Label text="Max. kmer alignability" GridPane.columnIndex="2" GridPane.rowIndex="4">
+                                         <tooltip>
+                                             <Tooltip text="Maximum repeat content for a fragment to be selected" />
+                                         </tooltip>
+                                         <GridPane.margin>
+                                             <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                         </GridPane.margin>
+                                     </Label>
+                                     <Label text="Maximum GC content (%)" GridPane.columnIndex="2" GridPane.rowIndex="5">
+                                         <tooltip>
+                                             <Tooltip text="Maximum percent GC content for a fragment to be selected" />
+                                         </tooltip>
+                                         <GridPane.margin>
+                                             <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                         </GridPane.margin>
+                                     </Label>
+                                     <Button alignment="CENTER" defaultButton="true" minHeight="30.0" minWidth="145.0" mnemonicParsing="false" onAction="#createViewPoints" styleClass="Button" stylesheets="@gophermain.css" text="Create viewpoints!" GridPane.columnSpan="2147483647" GridPane.halignment="CENTER" GridPane.rowIndex="9">
+                                         <GridPane.margin>
+                                             <Insets bottom="10.0" left="5.0" right="5.0" top="5.0" />
+                                         </GridPane.margin>
+                                     </Button>
+                              <Label text="Minimum probe count" GridPane.rowIndex="6">
+                                 <GridPane.margin>
                                     <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                                </GridPane.margin>
-                            </Label>
-                            <Label text="Genome" GridPane.rowIndex="2">
-                                <GridPane.margin>
+                                 </GridPane.margin>
+                              </Label>
+                              <TextField fx:id="minBaitCountTextField" minHeight="30.0" GridPane.columnIndex="1" GridPane.rowIndex="6">
+                                 <GridPane.margin>
+                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                 </GridPane.margin>
+                              </TextField>
+                              <Label text="Probe size" GridPane.rowIndex="7">
+                                 <GridPane.margin>
                                     <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                                </GridPane.margin>
-                            </Label>
-                            <Label text="Decompress genome" GridPane.rowIndex="3">
-                                <GridPane.margin>
+                                 </GridPane.margin>
+                              </Label>
+                              <Label text="Margin size" GridPane.columnIndex="2" GridPane.rowIndex="6">
+                                 <GridPane.margin>
+                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                 </GridPane.margin>
+                              </Label>
+                              <TextField fx:id="baitLengthTextField" minHeight="30.0" GridPane.columnIndex="1" GridPane.rowIndex="7">
+                                 <GridPane.margin>
+                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                 </GridPane.margin>
+                              </TextField>
+                              <TextField fx:id="marginSizeTextField" minHeight="30.0" GridPane.columnIndex="3" GridPane.rowIndex="6">
+                                 <GridPane.margin>
+                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                 </GridPane.margin>
+                              </TextField>
+                              <Label text="Unbalanced margins?" GridPane.rowIndex="8">
+                                 <GridPane.margin>
                                     <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                                </GridPane.margin>
-                            </Label>
-                            <Label text="Index genome FASTA" GridPane.columnIndex="3" GridPane.rowIndex="1">
-                                <GridPane.margin>
+                                 </GridPane.margin>
+                              </Label>
+                              <Label fx:id="patchedViewpointLabel" text="Patched viewpoints?" GridPane.columnIndex="2" GridPane.rowIndex="8">
+                                 <GridPane.margin>
+                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                 </GridPane.margin>
+                              </Label>
+                              <CheckBox fx:id="unbalancedMarginCheckbox" mnemonicParsing="false" onAction="#setUnbalancedMargin" GridPane.columnIndex="1" GridPane.rowIndex="8">
+                                 <GridPane.margin>
                                     <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                                </GridPane.margin>
-                            </Label>
-                            <Label text="Transcripts" GridPane.columnIndex="3" GridPane.rowIndex="2">
-                                <GridPane.margin>
+                                 </GridPane.margin>
+                              </CheckBox>
+                              <CheckBox fx:id="patchedViewpointCheckbox" mnemonicParsing="false" onAction="#setAllowPatching" GridPane.columnIndex="3" GridPane.rowIndex="8">
+                                 <GridPane.margin>
                                     <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                                </GridPane.margin>
-                            </Label>
-                            <Label text="Alignability map" GridPane.columnIndex="3" GridPane.rowIndex="3">
-                                <GridPane.margin>
-                                    <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                                </GridPane.margin>
-                            </Label>
-                            <ChoiceBox fx:id="genomeChoiceBox" prefHeight="30.0" prefWidth="145.0" stylesheets="@gophermain.css" GridPane.columnIndex="1" GridPane.rowIndex="1">
-                                <GridPane.margin>
-                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                                </GridPane.margin>
-                            </ChoiceBox>
-                            <Button fx:id="downloadGenomeButton" mnemonicParsing="false" onAction="#downloadGenome" prefHeight="30.0" prefWidth="145.0" styleClass="Button" stylesheets="@gophermain.css" text="Download" GridPane.columnIndex="1" GridPane.rowIndex="2">
-                                <GridPane.margin>
-                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                                </GridPane.margin>
-                            </Button>
-                            <Button fx:id="decompressGenomeButton" mnemonicParsing="false" onAction="#decompressGenome" prefHeight="30.0" prefWidth="145.0" styleClass="Button" stylesheets="@gophermain.css" text="Start" GridPane.columnIndex="1" GridPane.rowIndex="3">
-                                <GridPane.margin>
-                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                                </GridPane.margin>
-                            </Button>
-                            <Button fx:id="indexGenomeButton" mnemonicParsing="false" onAction="#indexGenome" prefHeight="30.0" prefWidth="145.0" styleClass="Button" stylesheets="@gophermain.css" text="Start" GridPane.columnIndex="4" GridPane.rowIndex="1">
-                                <GridPane.margin>
-                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                                </GridPane.margin>
-                            </Button>
-                            <Button fx:id="downloadTranscriptsButton" mnemonicParsing="false" onAction="#downloadRefGeneTranscripts" prefHeight="30.0" prefWidth="145.0" styleClass="Button" stylesheets="@gophermain.css" text="Download" GridPane.columnIndex="4" GridPane.rowIndex="2">
-                                <GridPane.margin>
-                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                                </GridPane.margin>
-                            </Button>
-                            <Button mnemonicParsing="false" onAction="#downloadAlignabilityMap" prefHeight="30.0" prefWidth="145.0" styleClass="Button" stylesheets="@gophermain.css" text="Download" GridPane.columnIndex="4" GridPane.rowIndex="3">
-                                <GridPane.margin>
-                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                                </GridPane.margin>
-                            </Button>
-                            <ProgressIndicator fx:id="genomeDownloadPI" progress="0.0" GridPane.columnIndex="2" GridPane.rowIndex="2" />
-                            <ProgressIndicator fx:id="genomeDecompressPI" progress="0.0" GridPane.columnIndex="2" GridPane.rowIndex="3" />
-                            <ProgressIndicator fx:id="genomeIndexPI" progress="0.0" GridPane.columnIndex="5" GridPane.rowIndex="1" />
-                            <ProgressIndicator fx:id="transcriptDownloadPI" progress="0.0" GridPane.columnIndex="5" GridPane.rowIndex="2" />
-                            <ProgressIndicator fx:id="alignabilityDownloadPI" progress="0.0" GridPane.columnIndex="5" GridPane.rowIndex="3" />
-                     <Label styleClass="biglabel" stylesheets="@gophermain.css" text="Data sources" GridPane.columnIndex="1">
-                        <padding>
-                           <Insets left="10.0" />
-                        </padding>
-                        <GridPane.margin>
-                           <Insets left="10.0" />
-                        </GridPane.margin>
-                     </Label>
-                     <Separator prefWidth="200.0" styleClass="sep" stylesheets="@gophermain.css">
-                        <GridPane.margin>
-                           <Insets left="10.0" />
-                        </GridPane.margin>
-                     </Separator>
-                        </GridPane>
-                        <VBox minWidth="785.0" prefHeight="69.0" styleClass="grid" stylesheets="@gophermain.css">
-                            <VBox.margin>
-                                <Insets />
-                            </VBox.margin>
-                            <HBox alignment="CENTER_LEFT" prefHeight="100.0" prefWidth="424.0">
-                                <Separator maxWidth="200.0" prefWidth="190.0" styleClass="sep" stylesheets="@gophermain.css">
-                                    <HBox.margin>
-                                        <Insets left="10.0" top="20.0" />
-                                    </HBox.margin>
-                                </Separator>
-                                <Label styleClass="biglabel" stylesheets="@gophermain.css" text="Enrichment targets">
-                                    <padding>
-                                        <Insets left="10.0" />
-                                    </padding>
-                                    <HBox.margin>
-                                        <Insets left="10.0" top="20.0" />
-                                    </HBox.margin>
-                                </Label>
-                            </HBox>
-                            <HBox prefHeight="44.0" prefWidth="830.0">
-                                <Region prefHeight="46.0" prefWidth="200.0" HBox.hgrow="ALWAYS" />
-                                <VBox alignment="CENTER" minWidth="200.0" prefHeight="200.0" prefWidth="100.0">
-                                    <HBox.margin>
-                                        <Insets top="10.0" />
-                                    </HBox.margin>
-                                    <Button mnemonicParsing="false" onAction="#enterGeneList" prefHeight="30.0" prefWidth="250.0" styleClass="Button" stylesheets="@gophermain.css" text="Target gene list" />
-                                    <Label fx:id="targetGeneLabel" styleClass="bluelabel" stylesheets="@gophermain.css">
-                                        <VBox.margin>
-                                            <Insets bottom="10.0" left="10.0" top="10.0" />
-                                        </VBox.margin>
-                                    </Label>
-                                </VBox>
-                                <Region prefHeight="200.0" prefWidth="200.0" />
-                                <VBox alignment="CENTER" minWidth="200.0" prefHeight="200.0" prefWidth="100.0">
-                                    <HBox.margin>
-                                        <Insets top="10.0" />
-                                    </HBox.margin>
-                                    <Button mnemonicParsing="false" onAction="#allProteinCodingGenes" prefHeight="30.0" prefWidth="300.0" styleClass="Button" stylesheets="@gophermain.css" text="All protein-coding genes" />
-                                    <Label fx:id="allGenesLabel" styleClass="bluelabel" stylesheets="@gophermain.css">
-                                        <VBox.margin>
-                                            <Insets bottom="10.0" left="10.0" top="10.0" />
-                                        </VBox.margin>
-                                    </Label>
-                                </VBox>
-                                <Region prefHeight="200.0" prefWidth="200.0" />
-                                <VBox alignment="CENTER" minWidth="200.0" prefHeight="200.0" prefWidth="100.0">
-                                    <HBox.margin>
-                                        <Insets top="10.0" />
-                                    </HBox.margin>
-                                    <Button mnemonicParsing="false" onAction="#enterBedFile" prefHeight="30.0" prefWidth="200.0" styleClass="Button" stylesheets="@gophermain.css" text="Enter BED file" />
-                                    <Label fx:id="bedTargetsLabel" styleClass="bluelabel" stylesheets="@gophermain.css">
-                                        <padding>
-                                            <Insets bottom="10.0" left="10.0" top="10.0" />
-                                        </padding>
-                                    </Label>
-                                </VBox>
-                                <Region prefHeight="200.0" prefWidth="200.0" />
-                            </HBox>
-                            <HBox alignment="CENTER_LEFT" prefHeight="25.0" prefWidth="830.0">
-                                <Separator maxWidth="200.0" prefWidth="190.0" styleClass="sep" stylesheets="@gophermain.css">
-                                    <HBox.margin>
-                                        <Insets bottom="10.0" left="10.0" top="20.0" />
-                                    </HBox.margin>
-                                </Separator>
-                                <Label styleClass="biglabel" stylesheets="@gophermain.css" text="Design parameters">
-                                    <padding>
-                                        <Insets left="10.0" />
-                                    </padding>
-                                    <HBox.margin>
-                                        <Insets bottom="10.0" left="10.0" top="20.0" />
-                                    </HBox.margin>
-                                </Label>
-                            </HBox>
-                        </VBox>
-                        <GridPane minWidth="785.0" styleClass="grid" VBox.vgrow="NEVER">
-                            <columnConstraints>
-                                <ColumnConstraints halignment="LEFT" hgrow="NEVER" minWidth="200.0" prefWidth="200.0" />
-                                <ColumnConstraints hgrow="NEVER" minWidth="210.0" prefWidth="210.0" />
-                                <ColumnConstraints hgrow="NEVER" minWidth="210.0" prefWidth="210.0" />
-                                <ColumnConstraints hgrow="NEVER" minWidth="210.0" prefWidth="210.0" />
-                            </columnConstraints>
-                            <rowConstraints>
-                        <RowConstraints minHeight="40.0" prefHeight="30.0" />
-                        <RowConstraints minHeight="40.0" prefHeight="30.0" />
-                                <RowConstraints minHeight="40.0" />
-                                <RowConstraints minHeight="40.0" />
-                                <RowConstraints minHeight="40.0" />
-                        <RowConstraints minHeight="40.0" prefHeight="30.0" />
-                        <RowConstraints minHeight="40.0" prefHeight="30.0" />
-                        <RowConstraints minHeight="40.0" prefHeight="30.0" />
-                                <RowConstraints minHeight="45.0" />
-                            </rowConstraints>
-                            <Label fx:id="sizeUpLabel" text="Upstream size" GridPane.rowIndex="2">
-                                <tooltip>
-                                    <Tooltip text="Number of nucleotides 5' of the target start position in which fragments will be sought" wrapText="true" />
-                                </tooltip>
-                                <GridPane.margin>
-                                    <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                                </GridPane.margin>
-                            </Label>
-                            <Label text="Minimum digest size" GridPane.rowIndex="3">
-                                <tooltip>
-                                    <Tooltip text="Minimum size in nucleotides for a fragment to be selected" />
-                                </tooltip>
-                                <GridPane.margin>
-                                    <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                                </GridPane.margin>
-                            </Label>
-                            <Label text="Minimum GC content (%)" GridPane.rowIndex="4">
-                                <tooltip>
-                                    <Tooltip text="Minimum percent GC content for a fragment to be selected" />
-                                </tooltip>
-                                <GridPane.margin>
-                                    <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                                </GridPane.margin>
-                            </Label>
-                            <TextField fx:id="sizeUpTextField" minHeight="30.0" promptText="1500" GridPane.columnIndex="1" GridPane.rowIndex="2">
-                                <GridPane.margin>
-                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                                </GridPane.margin>
-                                <tooltip>
-                                    <Tooltip text="Range (5')  to search for fragments (only used in extended approach)" />
-                                </tooltip>
-                            </TextField>
-                            <TextField fx:id="sizeDownTextField" minHeight="30.0" promptText="5000" GridPane.columnIndex="3" GridPane.rowIndex="2">
-                                <GridPane.margin>
-                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                                </GridPane.margin>
-                                <tooltip>
-                                    <Tooltip text="Range (3') to search for fragments (only used in extended approach)" />
-                                </tooltip>
-                            </TextField>
-                            <TextField fx:id="minFragSizeTextField" minHeight="30.0" promptText="130" GridPane.columnIndex="1" GridPane.rowIndex="3">
-                                <GridPane.margin>
-                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                                </GridPane.margin>
-                            </TextField>
-                            <TextField fx:id="maxKmerAlignabilityTextField" minHeight="30.0" promptText="10" GridPane.columnIndex="3" GridPane.rowIndex="3">
-                                <GridPane.margin>
-                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                                </GridPane.margin>
-                            </TextField>
-                            <TextField fx:id="minGCContentTextField" minHeight="30.0" GridPane.columnIndex="1" GridPane.rowIndex="4">
-                                <GridPane.margin>
-                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                                </GridPane.margin>
-                            </TextField>
-                            <TextField fx:id="maxGCContentTextField" minHeight="30.0" GridPane.columnIndex="3" GridPane.rowIndex="4">
-                                <GridPane.margin>
-                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                                </GridPane.margin>
-                            </TextField>
-                            <Label fx:id="sizeDownLabel" text="Downstream size" GridPane.columnIndex="2" GridPane.rowIndex="2">
-                                <tooltip>
-                                    <Tooltip text="Number of nucleotides 3' of the target start position in which fragments will be sought" />
-                                </tooltip>
-                                <GridPane.margin>
-                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                                </GridPane.margin>
-                            </Label>
-                            <Label text="Max. kmer alignability" GridPane.columnIndex="2" GridPane.rowIndex="3">
-                                <tooltip>
-                                    <Tooltip text="Maximum repeat content for a fragment to be selected" />
-                                </tooltip>
-                                <GridPane.margin>
-                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                                </GridPane.margin>
-                            </Label>
-                            <Label text="Maximum GC content (%)" GridPane.columnIndex="2" GridPane.rowIndex="4">
-                                <tooltip>
-                                    <Tooltip text="Maximum percent GC content for a fragment to be selected" />
-                                </tooltip>
-                                <GridPane.margin>
-                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                                </GridPane.margin>
-                            </Label>
-                            <Button alignment="CENTER" defaultButton="true" minHeight="30.0" minWidth="145.0" mnemonicParsing="false" onAction="#createViewPoints" styleClass="Button" stylesheets="@gophermain.css" text="Create viewpoints!" GridPane.columnSpan="2147483647" GridPane.halignment="CENTER" GridPane.rowIndex="8">
-                                <GridPane.margin>
-                                    <Insets bottom="10.0" left="5.0" right="5.0" top="5.0" />
-                                </GridPane.margin>
-                            </Button>
-                     <Label text="Minimum probe count" GridPane.rowIndex="5">
-                        <GridPane.margin>
-                           <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                        </GridPane.margin>
-                     </Label>
-                     <TextField fx:id="minBaitCountTextField" minHeight="30.0" GridPane.columnIndex="1" GridPane.rowIndex="5">
-                        <GridPane.margin>
-                           <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                        </GridPane.margin>
-                     </TextField>
-                     <Label text="Probe size" GridPane.rowIndex="6">
-                        <GridPane.margin>
-                           <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                        </GridPane.margin>
-                     </Label>
-                     <Label text="Margin size" GridPane.columnIndex="2" GridPane.rowIndex="5">
-                        <GridPane.margin>
-                           <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                        </GridPane.margin>
-                     </Label>
-                     <TextField fx:id="baitLengthTextField" GridPane.columnIndex="1" GridPane.rowIndex="6">
-                        <GridPane.margin>
-                           <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                        </GridPane.margin>
-                     </TextField>
-                     <TextField fx:id="marginSizeTextField" GridPane.columnIndex="3" GridPane.rowIndex="5">
-                        <GridPane.margin>
-                           <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                        </GridPane.margin>
-                     </TextField>
-                     <Label text="Unbalanced margins?" GridPane.rowIndex="7">
-                        <GridPane.margin>
-                           <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                        </GridPane.margin>
-                     </Label>
-                     <Label fx:id="patchedViewpointLabel" text="Patched viewpoints?" GridPane.columnIndex="2" GridPane.rowIndex="7">
-                        <GridPane.margin>
-                           <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                        </GridPane.margin>
-                     </Label>
-                     <CheckBox fx:id="unbalancedMarginCheckbox" mnemonicParsing="false" onAction="#setUnbalancedMargin" GridPane.columnIndex="1" GridPane.rowIndex="7">
-                        <GridPane.margin>
-                           <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                        </GridPane.margin>
-                     </CheckBox>
-                     <CheckBox fx:id="patchedViewpointCheckbox" mnemonicParsing="false" onAction="#setAllowPatching" GridPane.columnIndex="3" GridPane.rowIndex="7">
-                        <GridPane.margin>
-                           <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                        </GridPane.margin>
-                     </CheckBox>
-                            <Label text="Approach">
-                                <GridPane.margin>
-                                    <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                                </GridPane.margin>
-                            </Label>
-                            <ChoiceBox fx:id="approachChoiceBox" prefHeight="30.0" prefWidth="145.0" GridPane.columnIndex="1">
-                                <GridPane.margin>
-                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                                </GridPane.margin>
-                            </ChoiceBox>
-                            <Label text="Restriction enzyme(s)" GridPane.rowIndex="1">
-                                <GridPane.margin>
-                                    <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                                </GridPane.margin>
-                            </Label>
-                            <Button fx:id="chooseEnzymeButton" mnemonicParsing="false" onAction="#chooseEnzymes" prefHeight="30.0" prefWidth="145.0" styleClass="Button" stylesheets="@gophermain.css" text="Choose" GridPane.columnIndex="1" GridPane.rowIndex="1">
-                                <GridPane.margin>
-                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                                </GridPane.margin>
-                            </Button>
-                            <Label fx:id="restrictionEnzymeLabel" styleClass="bluelabel" text="..." GridPane.columnIndex="2" GridPane.rowIndex="1">
-                                <GridPane.margin>
-                                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                                </GridPane.margin>
-                            </Label>
-                        </GridPane>
-                    </VBox>
-                </Tab>
-                <Tab id="analysistab" fx:id="analysistab" closable="false" text="Analysis">
-                    <StackPane fx:id="analysisPane" />
-                </Tab>
-            </TabPane>
-        </center>
-    </BorderPane>
-</ScrollPane>
+                                 </GridPane.margin>
+                              </CheckBox>
+                                     <Label text="Approach" GridPane.rowIndex="1">
+                                         <GridPane.margin>
+                                             <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+                                         </GridPane.margin>
+                                     </Label>
+                                     <ChoiceBox fx:id="approachChoiceBox" prefHeight="30.0" prefWidth="145.0" GridPane.columnIndex="1" GridPane.rowIndex="1">
+                                         <GridPane.margin>
+                                             <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                         </GridPane.margin>
+                                     </ChoiceBox>
+                                     <Label text="Restriction enzyme(s)" GridPane.rowIndex="2">
+                                         <GridPane.margin>
+                                             <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+                                         </GridPane.margin>
+                                     </Label>
+                                     <Button fx:id="chooseEnzymeButton" mnemonicParsing="false" onAction="#chooseEnzymes" prefHeight="30.0" prefWidth="145.0" styleClass="Button" stylesheets="@gophermain.css" text="Choose" GridPane.columnIndex="1" GridPane.rowIndex="2">
+                                         <GridPane.margin>
+                                             <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                         </GridPane.margin>
+                                     </Button>
+                                     <Label fx:id="restrictionEnzymeLabel" styleClass="bluelabel" text="..." GridPane.columnIndex="2" GridPane.rowIndex="2">
+                                         <GridPane.margin>
+                                             <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                                         </GridPane.margin>
+                                     </Label>
+                                      <Separator maxWidth="200.0" prefWidth="190.0" styleClass="sep" stylesheets="@gophermain.css" />
+                                      <Label styleClass="biglabel" stylesheets="@gophermain.css" text="Design parameters" GridPane.columnIndex="1">
+                                          <padding>
+                                              <Insets left="10.0" />
+                                          </padding>
+                                      </Label>
+                                 </GridPane>
+                             </VBox>
+                     </children>
+                  </StackPane>
+               </content>
+            </ScrollPane>
+             </Tab>
+             <Tab id="analysistab" fx:id="analysistab" closable="false" text="Analysis">
+                 <StackPane fx:id="analysisPane" alignment="TOP_CENTER" />
+             </Tab>
+         </TabPane>
+     </center>
+ </BorderPane>

--- a/src/main/java/gopher/gui/viewpointpanel/URLMaker.java
+++ b/src/main/java/gopher/gui/viewpointpanel/URLMaker.java
@@ -29,13 +29,15 @@ class URLMaker {
     private static final int OFFSET = 200;
 
 
-
-
-    URLMaker(Model model){
+    URLMaker(Model model, int width) {
         this.genomebuild=model.getGenomeBuild();
-        xdim=Math.min(UCSC_DEFAULT_WIDTH,model.getXdim());
+        xdim=width;
         this.enzymeString = model.getChosenEnzymelist().stream().map(RestrictionEnzyme::getName).collect(Collectors.joining(","));
         logger.trace(String.format("setting genomebuild to %s with default image width of %d",genomebuild,xdim));
+    }
+
+    URLMaker(Model model){
+        this(model, UCSC_DEFAULT_WIDTH);
     }
 
 

--- a/src/main/java/gopher/gui/viewpointpanel/ViewPointPresenter.java
+++ b/src/main/java/gopher/gui/viewpointpanel/ViewPointPresenter.java
@@ -53,6 +53,9 @@ public class ViewPointPresenter implements Initializable {
             "FF99FF", "99FFFF","CCFF99","FFE5CC","FFD700","9ACD32","7FFFD4","FFB6C1","FFFACD",
             "FFE4E1","F0FFF0","F0FFFF"};
 
+    @FXML
+    private SplitPane viewPointSplitPane;
+
     /** The top-level Pane which contains all other graphical elements of this controller.*/
     @FXML
     private ScrollPane contentScrollPane;
@@ -216,7 +219,10 @@ public class ViewPointPresenter implements Initializable {
         ucscWebEngine = ucscContentWebView.getEngine();
         ucscWebEngine.loadContent(INITIAL_HTML_CONTENT);
 
-    // Todo -- not catching lack of internet connect error.
+        // allow content of viewpoint tab to be resized to follow width of UCSC image
+        viewPointSplitPane.prefWidthProperty().bind(ucscContentWebView.widthProperty());
+
+        // Todo -- not catching lack of internet connect error.
         ucscWebEngine.setOnError(new EventHandler<WebErrorEvent>() {
             @Override
             public void handle(WebErrorEvent event) {

--- a/src/main/java/gopher/gui/viewpointpanel/viewpoint.fxml
+++ b/src/main/java/gopher/gui/viewpointpanel/viewpoint.fxml
@@ -10,72 +10,77 @@
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.RowConstraints?>
+<?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.web.WebView?>
 
-<ScrollPane fx:id="contentScrollPane" fitToHeight="true" fitToWidth="true" xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1" fx:controller="gopher.gui.viewpointpanel.ViewPointPresenter">
-    <SplitPane dividerPositions="0.5" minHeight="510.0" minWidth="1165.0" orientation="VERTICAL">
-        <WebView fx:id="ucscContentWebView" minHeight="-1.0" minWidth="-1.0" prefHeight="-1.0" prefWidth="-1.0" />
-        <VBox>
-            <GridPane>
-                <columnConstraints>
-                    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                </columnConstraints>
-                <rowConstraints>
-                    <RowConstraints minHeight="30.0" prefHeight="30.0" vgrow="NEVER" />
-                    <RowConstraints minHeight="30.0" prefHeight="30.0" vgrow="NEVER" />
-                    <RowConstraints minHeight="40.0" percentHeight="0.0" />
-                </rowConstraints>
-                <Label fx:id="viewpointScoreLabel" maxWidth="1.7976931348623157E308" styleClass="mylabel" GridPane.columnSpan="2147483647" />
-                <Button fx:id="zoomOutButton" maxHeight="30.0" maxWidth="90.0" minHeight="30.0" minWidth="90.0" mnemonicParsing="false" onAction="#zoomOut" prefHeight="30.0" prefWidth="90.0" text="Zoom out" GridPane.halignment="CENTER" GridPane.rowIndex="2">
-                    <padding>
-                        <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                    </padding>
-                    <GridPane.margin>
-                        <Insets />
-                    </GridPane.margin>
-                </Button>
-                <Button fx:id="zoomInButton" maxHeight="30.0" maxWidth="90.0" minHeight="30.0" minWidth="90.0" mnemonicParsing="false" onAction="#zoomIn" prefHeight="30.0" prefWidth="90.0" text="Zoom In" GridPane.columnIndex="1" GridPane.halignment="CENTER" GridPane.rowIndex="2">
-                    <GridPane.margin>
-                        <Insets left="10.0" right="10.0" />
-                    </GridPane.margin>
-                </Button>
-                <Button fx:id="deleteButton" maxHeight="30.0" maxWidth="90.0" minHeight="30.0" minWidth="90.0" mnemonicParsing="false" onAction="#deleteThisViewPoint" prefHeight="30.0" prefWidth="90.0" text="Delete" GridPane.columnIndex="2" GridPane.halignment="CENTER" GridPane.rowIndex="2">
-                    <GridPane.margin>
-                        <Insets left="10.0" right="10.0" />
-                    </GridPane.margin>
-                </Button>
-                <Button fx:id="copyToClipboardButton" maxHeight="30.0" maxWidth="90.0" minHeight="30.0" minWidth="90.0" mnemonicParsing="false" onAction="#copyToClipboard" prefHeight="30.0" prefWidth="90.0" text="Copy URL" GridPane.columnIndex="3" GridPane.halignment="CENTER" GridPane.rowIndex="2">
-                    <GridPane.margin>
-                        <Insets left="10.0" right="10.0" />
-                    </GridPane.margin>
-                </Button>
-                <Button cancelButton="true" maxHeight="30.0" maxWidth="90.0" minHeight="30.0" minWidth="90.0" mnemonicParsing="false" onAction="#closeButtonAction" prefHeight="30.0" prefWidth="90.0" text="Close" GridPane.columnIndex="4" GridPane.halignment="CENTER" GridPane.rowIndex="2">
-                    <GridPane.margin>
-                        <Insets left="10.0" right="10.0" />
-                    </GridPane.margin>
-                </Button>
-                <Label fx:id="viewpointExplanationLabel" maxWidth="1.7976931348623157E308" styleClass="mylabel" GridPane.columnSpan="2147483647" GridPane.rowIndex="1" />
-            </GridPane>
-            <TableView fx:id="segmentsTableView" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefWidth="1200.0" stylesheets="@viewpoint.css" VBox.vgrow="ALWAYS">
-                <columns>
-                    <TableColumn fx:id="isSelectedTableColumn" editable="false" maxWidth="75.0" minWidth="75.0" prefWidth="75.0" resizable="false" sortable="false" text="Select" />
-                    <TableColumn fx:id="locationTableColumn" editable="false" maxWidth="1.7976931348623157E308" minWidth="250.0" prefWidth="-1.0" text="Location" />
-                    <TableColumn fx:id="segmentLengthColumn" editable="false" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="-1.0" styleClass="mycolumn" text="bp" />
-                    <TableColumn fx:id="alignabilityContentColumn" editable="false" maxWidth="1.7976931348623157E308" minWidth="175.0" prefWidth="-1.0" styleClass="mycolumn" text="Alignability" />
-                    <TableColumn fx:id="repeatContentUpColumn" editable="false" maxWidth="1.7976931348623157E308" minWidth="175.0" prefWidth="-1.0" styleClass="mycolumn" text="Repeat content" />
-                    <TableColumn fx:id="gcContentUpDownColumn" editable="false" maxWidth="1.7976931348623157E308" minWidth="175.0" prefWidth="-1.0" styleClass="mycolumn" text="GC content" />
-                    <TableColumn fx:id="numberOfBaitsColumn" editable="false" maxWidth="1.7976931348623157E308" minWidth="120.0" prefWidth="-1.0" styleClass="mycolumn" text="Probes" />
-                    <TableColumn fx:id="colorTableColumn" editable="false" maxWidth="1.0" minWidth="1.0" prefWidth="1.0" resizable="false" sortable="false" text="Column X" />
-                </columns>
-            <columnResizePolicy>
-               <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
-            </columnResizePolicy>
-            </TableView>
-        </VBox>
-    </SplitPane>
+<ScrollPane fx:id="contentScrollPane" fitToHeight="true" fitToWidth="true" xmlns="http://javafx.com/javafx/8.0.121" xmlns:fx="http://javafx.com/fxml/1" fx:controller="gopher.gui.viewpointpanel.ViewPointPresenter">
+   <StackPane alignment="TOP_CENTER">
+      <children>
+          <SplitPane fx:id="viewPointSplitPane" dividerPositions="0.35" maxWidth="1600.0" minHeight="560.0" minWidth="1100.0" orientation="VERTICAL" prefWidth="1100.0" StackPane.alignment="TOP_CENTER">
+              <WebView fx:id="ucscContentWebView" minHeight="300.0" minWidth="1100.0" prefHeight="-1.0" prefWidth="-1.0" />
+              <VBox>
+                  <GridPane>
+                      <columnConstraints>
+                          <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                          <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                          <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                          <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                          <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                      </columnConstraints>
+                      <rowConstraints>
+                          <RowConstraints minHeight="30.0" prefHeight="30.0" vgrow="NEVER" />
+                          <RowConstraints minHeight="30.0" prefHeight="30.0" vgrow="NEVER" />
+                          <RowConstraints minHeight="40.0" percentHeight="0.0" />
+                      </rowConstraints>
+                      <Label fx:id="viewpointScoreLabel" maxWidth="1.7976931348623157E308" styleClass="mylabel" GridPane.columnSpan="2147483647" />
+                      <Button fx:id="zoomOutButton" maxHeight="30.0" maxWidth="90.0" minHeight="30.0" minWidth="90.0" mnemonicParsing="false" onAction="#zoomOut" prefHeight="30.0" prefWidth="90.0" text="Zoom out" GridPane.halignment="CENTER" GridPane.rowIndex="2">
+                          <padding>
+                              <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                          </padding>
+                          <GridPane.margin>
+                              <Insets />
+                          </GridPane.margin>
+                      </Button>
+                      <Button fx:id="zoomInButton" maxHeight="30.0" maxWidth="90.0" minHeight="30.0" minWidth="90.0" mnemonicParsing="false" onAction="#zoomIn" prefHeight="30.0" prefWidth="90.0" text="Zoom In" GridPane.columnIndex="1" GridPane.halignment="CENTER" GridPane.rowIndex="2">
+                          <GridPane.margin>
+                              <Insets left="10.0" right="10.0" />
+                          </GridPane.margin>
+                      </Button>
+                      <Button fx:id="deleteButton" maxHeight="30.0" maxWidth="90.0" minHeight="30.0" minWidth="90.0" mnemonicParsing="false" onAction="#deleteThisViewPoint" prefHeight="30.0" prefWidth="90.0" text="Delete" GridPane.columnIndex="2" GridPane.halignment="CENTER" GridPane.rowIndex="2">
+                          <GridPane.margin>
+                              <Insets left="10.0" right="10.0" />
+                          </GridPane.margin>
+                      </Button>
+                      <Button fx:id="copyToClipboardButton" maxHeight="30.0" maxWidth="90.0" minHeight="30.0" minWidth="90.0" mnemonicParsing="false" onAction="#copyToClipboard" prefHeight="30.0" prefWidth="90.0" text="Copy URL" GridPane.columnIndex="3" GridPane.halignment="CENTER" GridPane.rowIndex="2">
+                          <GridPane.margin>
+                              <Insets left="10.0" right="10.0" />
+                          </GridPane.margin>
+                      </Button>
+                      <Button cancelButton="true" maxHeight="30.0" maxWidth="90.0" minHeight="30.0" minWidth="90.0" mnemonicParsing="false" onAction="#closeButtonAction" prefHeight="30.0" prefWidth="90.0" text="Close" GridPane.columnIndex="4" GridPane.halignment="CENTER" GridPane.rowIndex="2">
+                          <GridPane.margin>
+                              <Insets left="10.0" right="10.0" />
+                          </GridPane.margin>
+                      </Button>
+                      <Label fx:id="viewpointExplanationLabel" maxWidth="1.7976931348623157E308" styleClass="mylabel" GridPane.columnSpan="2147483647" GridPane.rowIndex="1" />
+                  </GridPane>
+                  <TableView fx:id="segmentsTableView" stylesheets="@viewpoint.css" VBox.vgrow="ALWAYS">
+                      <columns>
+                          <TableColumn fx:id="isSelectedTableColumn" editable="false" maxWidth="75.0" minWidth="75.0" prefWidth="75.0" resizable="false" sortable="false" text="Select" />
+                          <TableColumn fx:id="locationTableColumn" editable="false" maxWidth="1.7976931348623157E308" minWidth="250.0" prefWidth="-1.0" text="Location" />
+                          <TableColumn fx:id="segmentLengthColumn" editable="false" maxWidth="1.7976931348623157E308" minWidth="100.0" prefWidth="-1.0" styleClass="mycolumn" text="bp" />
+                          <TableColumn fx:id="alignabilityContentColumn" editable="false" maxWidth="1.7976931348623157E308" minWidth="175.0" prefWidth="-1.0" styleClass="mycolumn" text="Alignability" />
+                          <TableColumn fx:id="repeatContentUpColumn" editable="false" maxWidth="1.7976931348623157E308" minWidth="175.0" prefWidth="-1.0" styleClass="mycolumn" text="Repeat content" />
+                          <TableColumn fx:id="gcContentUpDownColumn" editable="false" maxWidth="1.7976931348623157E308" minWidth="175.0" prefWidth="-1.0" styleClass="mycolumn" text="GC content" />
+                          <TableColumn fx:id="numberOfBaitsColumn" editable="false" maxWidth="1.7976931348623157E308" minWidth="120.0" prefWidth="-1.0" styleClass="mycolumn" text="Probes" />
+                          <TableColumn fx:id="colorTableColumn" editable="false" maxWidth="1.0" minWidth="1.0" prefWidth="1.0" resizable="false" sortable="false" text="Column X" />
+                      </columns>
+                  <columnResizePolicy>
+                     <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
+                  </columnResizePolicy>
+                  </TableView>
+              </VBox>
+          </SplitPane>
+      </children>
+   </StackPane>
 </ScrollPane>


### PR DESCRIPTION
These changes relate to issue #251. I've modified FXML files to change layout of the app. Now the whole UCSC image should be displayed correctly.

I would like to ask you if you like how the content of tabs (setup, vpanalysis and viewpoint) looks like now. The content is *centered* and it does not grow until infinity when width of the app window is increased. When the window size is lowered, scroll bars appear in the right and bottom part.

I set the width values to be rendered nicely on Full HD monitors (1920 * 1080 px), I think that most of the people are using these sizes these days.