### PR TITLE
Prevent creation of `gopher.Gopher` directory.

### DIFF
--- a/src/main/java/gopher/gui/entrezgenetable/EntrezGenePresenter.java
+++ b/src/main/java/gopher/gui/entrezgenetable/EntrezGenePresenter.java
@@ -4,6 +4,7 @@ package gopher.gui.entrezgenetable;
 import com.google.common.collect.ImmutableList;
 import gopher.framework.Signal;
 import gopher.gui.popupdialog.PopupFactory;
+import gopher.io.Platform;
 import gopher.io.RefGeneParser;
 import gopher.model.GopherGene;
 import gopher.model.Model;
@@ -45,6 +46,8 @@ public class EntrezGenePresenter implements Initializable {
     private static Logger logger = Logger.getLogger(EntrezGenePresenter.class.getName());
     /** This webview explains how to enter genes */
     @FXML private WebView wview;
+
+    private WebEngine webEngine;
     /** A reference to the Model. We will use it to add genes information to the model.*/
     private Model model=null;
     /** This class parses {@link GopherGene} objects from the refGene.txt.gz file. */
@@ -62,6 +65,8 @@ public class EntrezGenePresenter implements Initializable {
     @Override
     public void initialize(URL location, ResourceBundle resources) {
         isvalidated=false;
+        webEngine = wview.getEngine();
+        webEngine.setUserDataDirectory(new File(Platform.getWebEngineUserDataDirectory(), getClass().getCanonicalName()));
     }
 
    public void setSignal(Consumer<Signal> signal) {
@@ -127,8 +132,7 @@ public class EntrezGenePresenter implements Initializable {
 
    /** Sets the text that will be shown in the HTML View. */
     void setData(String html) {
-        WebEngine engine = wview.getEngine();
-        engine.loadContent(html);
+        webEngine.loadContent(html);
     }
 
     @FXML

--- a/src/main/java/gopher/gui/help/HelpPresenter.java
+++ b/src/main/java/gopher/gui/help/HelpPresenter.java
@@ -11,6 +11,7 @@ import javafx.scene.web.WebView;
 import gopher.framework.Signal;
 
 
+import java.io.File;
 import java.net.URL;
 import java.util.ResourceBundle;
 import java.util.function.Consumer;
@@ -23,18 +24,21 @@ public class HelpPresenter implements Initializable {
     @FXML
     WebView wview;
 
+    private WebEngine webEngine;
+
     @Override
     public void initialize(URL location, ResourceBundle resources) {
-        // no op
+        webEngine = wview.getEngine();
+        webEngine.setUserDataDirectory(new File(gopher.io.Platform.getWebEngineUserDataDirectory(), getClass().getCanonicalName()));
     }
 
     public void setData(String html) {
-        WebEngine engine = wview.getEngine();
-        engine.loadContent(html);
-        engine.locationProperty().addListener(new ChangeListener<String>() {
+
+        webEngine.loadContent(html);
+        webEngine.locationProperty().addListener(new ChangeListener<String>() {
             @Override public void changed(ObservableValue<? extends String> ov, final String oldLoc, final String loc) {
                 if (!loc.contains("google.com")) {
-                    Platform.runLater(() -> engine.load(oldLoc)); // new Runnable
+                    Platform.runLater(() -> webEngine.load(oldLoc)); // new Runnable
                 }
             }
         });

--- a/src/main/java/gopher/gui/help/HelpViewFactory.java
+++ b/src/main/java/gopher/gui/help/HelpViewFactory.java
@@ -1,14 +1,17 @@
 package gopher.gui.help;
 
+import gopher.io.Platform;
 import javafx.scene.Scene;
 import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonBar;
 import javafx.scene.control.ButtonType;
 import javafx.scene.layout.Region;
+import javafx.scene.web.WebEngine;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
 import org.apache.log4j.Logger;
 
+import java.io.File;
 import java.util.Optional;
 
 /**
@@ -70,7 +73,9 @@ public class HelpViewFactory {
             Stage window;
             window = new Stage();
             WebView web = new WebView();
-            web.getEngine().load(READTHEDOCS_SITE);
+            WebEngine webEngine = web.getEngine();
+            webEngine.setUserDataDirectory(new File(Platform.getWebEngineUserDataDirectory(), HelpViewFactory.class.getCanonicalName()));
+            webEngine.load(READTHEDOCS_SITE);
             Scene scene = new Scene(web);
             window.setScene(scene);
             window.show();

--- a/src/main/java/gopher/gui/popupdialog/PopupPresenter.java
+++ b/src/main/java/gopher/gui/popupdialog/PopupPresenter.java
@@ -1,5 +1,6 @@
 package gopher.gui.popupdialog;
 
+import gopher.io.Platform;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
@@ -14,6 +15,7 @@ import org.apache.log4j.Logger;
 import gopher.framework.Signal;
 
 
+import java.io.File;
 import java.net.URL;
 import java.util.ResourceBundle;
 import java.util.function.Consumer;
@@ -24,6 +26,8 @@ public class PopupPresenter  implements Initializable  {
     AnchorPane apane;
     @FXML
     private WebView wview;
+
+    private WebEngine webEngine;
 
     @FXML private Button cancelButon;
     @FXML private Button okButton;
@@ -37,6 +41,8 @@ public class PopupPresenter  implements Initializable  {
     private Consumer<Signal> signal;
     @Override
     public void initialize(URL location, ResourceBundle resources) {
+        webEngine = wview.getEngine();
+        webEngine.setUserDataDirectory(new File(Platform.getWebEngineUserDataDirectory(), getClass().getCanonicalName()));
     }
 
     public void setSignal(Consumer<Signal> signal) {
@@ -44,8 +50,7 @@ public class PopupPresenter  implements Initializable  {
     }
 
     public void setData(String html) {
-        WebEngine engine = wview.getEngine();
-        engine.loadContent(html);
+        webEngine.loadContent(html);
     }
 
     @FXML public void cancelButtonClicked(ActionEvent e) {

--- a/src/main/java/gopher/gui/qcCheckPane/QCCheckPresenter.java
+++ b/src/main/java/gopher/gui/qcCheckPane/QCCheckPresenter.java
@@ -1,5 +1,6 @@
 package gopher.gui.qcCheckPane;
 
+import gopher.io.Platform;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
@@ -10,6 +11,7 @@ import javafx.scene.web.WebView;
 import org.apache.log4j.Logger;
 import gopher.framework.Signal;
 
+import java.io.File;
 import java.net.URL;
 import java.util.ResourceBundle;
 import java.util.function.Consumer;
@@ -19,6 +21,8 @@ public class QCCheckPresenter implements Initializable {
     static Logger logger = Logger.getLogger(QCCheckPresenter.class.getName());
     @FXML
     private WebView wview;
+
+    private WebEngine webEngine;
 
     @FXML private Button cancelButon;
     @FXML private Button continueButton;
@@ -30,6 +34,8 @@ public class QCCheckPresenter implements Initializable {
 
     @Override
     public void initialize(URL location, ResourceBundle resources) {
+        webEngine = wview.getEngine();
+        webEngine.setUserDataDirectory(new File(Platform.getWebEngineUserDataDirectory(), getClass().getCanonicalName()));
     }
 
     public QCCheckPresenter() {
@@ -40,8 +46,7 @@ public class QCCheckPresenter implements Initializable {
     }
 
     public void setData(String html) {
-        WebEngine engine = wview.getEngine();
-        engine.loadContent(html);
+        webEngine.loadContent(html);
     }
 
     @FXML public void cancelButtonClicked(ActionEvent e) {

--- a/src/main/java/gopher/gui/viewpointpanel/ViewPointPresenter.java
+++ b/src/main/java/gopher/gui/viewpointpanel/ViewPointPresenter.java
@@ -27,6 +27,7 @@ import javafx.scene.web.WebView;
 import javafx.stage.Stage;
 import org.apache.log4j.Logger;
 
+import java.io.File;
 import java.net.URL;
 import java.util.Comparator;
 import java.util.List;
@@ -157,7 +158,6 @@ public class ViewPointPresenter implements Initializable {
         String url= urlmaker.getImageURL(viewpoint,getHighlightRegions());
         StackPane sproot = new StackPane();
         final ProgressIndicator progress = new ProgressIndicator(); // or you can use ImageView with animated gif instead
-        this.ucscWebEngine = ucscContentWebView.getEngine();
         this.ucscWebEngine.load(url);
 
         progress.setProgress(ProgressIndicator.INDETERMINATE_PROGRESS);
@@ -217,6 +217,7 @@ public class ViewPointPresenter implements Initializable {
     @Override
     public void initialize(URL location, ResourceBundle resources) {
         ucscWebEngine = ucscContentWebView.getEngine();
+        ucscWebEngine.setUserDataDirectory(new File(gopher.io.Platform.getWebEngineUserDataDirectory(), getClass().getCanonicalName()));
         ucscWebEngine.loadContent(INITIAL_HTML_CONTENT);
 
         // allow content of viewpoint tab to be resized to follow width of UCSC image

--- a/src/main/java/gopher/io/Platform.java
+++ b/src/main/java/gopher/io/Platform.java
@@ -1,6 +1,8 @@
 package gopher.io;
 
 
+import org.apache.log4j.Logger;
+
 import java.io.File;
 import java.io.IOException;
 
@@ -9,6 +11,11 @@ import java.io.IOException;
  * this would be /home/username/.gopher/...
  */
 public class Platform {
+
+    public static final String WEB_ENGINE_DIRNAME = "web_engine_user_data";
+
+    private static final Logger LOGGER = Logger.getLogger(Platform.class);
+
 
     /**
      * This method creates directory where Gopher stores global settings, if the directory does not exist.
@@ -21,10 +28,34 @@ public class Platform {
         if (target == null)
             throw new IOException("Operating system not recognized. Supported systems: WINDOWS, OSX, LINUX");
 
-        if (!target.isDirectory()) { // either does not exist or is not a directory
+        if (target.isFile()) { // a file exists at the place where we want to create a directory
+            LOGGER.debug(String.format("Deleting the file '%s', we want to create a directory here", target.getAbsolutePath()));
+            boolean success = target.delete();
+            if (!success) {
+                throw new IOException("Unable to create directory for storing Gopher settings at '" + target.getAbsolutePath() + "'");
+            } else {
+                LOGGER.debug("Success!");
+            }
+        }
+
+        if (!target.isDirectory()) {
+            LOGGER.debug(String.format("Creating directory to store global settings at '%s'", target.getAbsolutePath()));
             boolean success = target.mkdirs();
             if (!success)
                 throw new IOException("Unable to create directory for storing Gopher settings at '" + target.getAbsolutePath() + "'");
+            else
+                LOGGER.debug("Success!");
+        }
+
+        // create directory for WebEngine user data
+        File userDataDir = new File(target, WEB_ENGINE_DIRNAME);
+
+        if (userDataDir.isFile()) {
+            target.delete();
+        }
+        if (!userDataDir.isDirectory()) { // either does not exist or is not a directory
+            boolean success = userDataDir.mkdirs();
+            LOGGER.debug("Created userData dir");
         }
     }
 
@@ -43,17 +74,45 @@ public class Platform {
         File osxPath = new File(System.getProperty("user.home") + File.separator + ".gopher");
 
         switch (platform) {
-            case LINUX: return linuxPath;
-            case WINDOWS: return windowsPath;
-            case OSX: return osxPath;
-            case UNKNOWN: return null;
+            case LINUX:
+                return linuxPath;
+            case WINDOWS:
+                return windowsPath;
+            case OSX:
+                return osxPath;
+            case UNKNOWN:
+                return null;
             default:
                 return null;
         }
     }
 
+
+    /**
+     * Get a directory where {@link javafx.scene.web.WebEngine}s used to render html data store <code>userData</code>.
+     * In order to use the returned <code>userDataDirectory</code> it must actually exist in the file system. Creation
+     * of the folder is taken care of in {@link #createGopherDir()} method. If it fails, this method will return <code>null</code>.
+     *
+     * @return {@link File} leading to <em>existing</em> userData directory or <code>null</code> if {@link #getGopherDir()} returns <code>null</code>
+     */
+    public static File getWebEngineUserDataDirectory() {
+
+        File gopherDir = getGopherDir();
+
+        File webEngineUserData = null;
+        if (gopherDir != null)
+            webEngineUserData = new File(gopherDir, WEB_ENGINE_DIRNAME);
+
+        if (webEngineUserData != null && webEngineUserData.isDirectory())
+            return webEngineUserData;
+        else
+            return null;
+    }
+
+
     /**
      * Get the absolute path to the viewpoint file, which is a serialized Java file (suffix {@code .ser}).
+     *
      * @param basename The plain viewpoint name, e.g., human37cd4
      * @return the absolute path,e.g., /home/user/data/immunology/human37cd4.ser
      */
@@ -62,14 +121,17 @@ public class Platform {
         return new String(dir + File.separator + basename + ".ser");
     }
 
+
     /**
      * Get the absolute path to the log file.
+     *
      * @return the absolute path,e.g., /home/user/.gopher/gopher.log
      */
     public static String getAbsoluteLogPath() {
         File dir = getGopherDir();
-        return new String(dir + File.separator +  "gopher.log");
+        return new String(dir + File.separator + "gopher.log");
     }
+
 
     /* Based on this post: http://www.mkyong.com/java/how-to-detect-os-in-java-systemgetpropertyosname/ */
     private static CurrentPlatform figureOutPlatform() {
@@ -95,10 +157,16 @@ public class Platform {
 
         private String name;
 
-        CurrentPlatform(String n) {this.name = n; }
+
+        CurrentPlatform(String n) {
+            this.name = n;
+        }
+
 
         @Override
-        public String toString() { return this.name; }
+        public String toString() {
+            return this.name;
+        }
     }
 
 }


### PR DESCRIPTION
`javafx.scene.web.WebEngine` (used to render *html* data in Gopher) stores *"userData"* in user's home directory by default. This results in creation of the `gopher.Gopher` directory.

Now the *userData* is stored in the `.gopher/web_engine_user_data` directory. All usages of the `WebEngine` in Gopher were modified to store the data in this directory.

Please test it and merge if it works.