### PR TITLE
address #276

### DIFF
--- a/src/main/java/gopher/Gopher.java
+++ b/src/main/java/gopher/Gopher.java
@@ -89,6 +89,15 @@ public class Gopher extends Application {
     }
 
     public static void main(String[] args) {
+        String jre_version = System.getProperty("java.specification.version");
+        if (!jre_version.equals("1.8")) {
+            JOptionPane.showMessageDialog(null,
+                    "Your current Java version "
+                            + jre_version
+                            + " is not supported and GOPHER may not work correctly.\n"
+                            + "Please install Java version 1.8 (Java 8) from: https://www.java.com/download/",
+                    "Java version warning", JOptionPane.WARNING_MESSAGE);
+        }
         Locale.setDefault(new Locale("en", "US"));
         launch(args);
     }


### PR DESCRIPTION
This displays a warning message when GOPHER is started in any JRE version except JRE version 1.8 (Java 8). As discussed with @hansenp, the application will resume after the user closes the warning message.

![image](https://user-images.githubusercontent.com/5254933/44857330-dafa8a80-ac6f-11e8-8e11-cfda84b95382.png)
