### PR TITLE
Added xenTro9 and danRer10 genomes.

### DIFF
--- a/src/main/java/gopher/gui/gophermain/GopherMainPresenter.java
+++ b/src/main/java/gopher/gui/gophermain/GopherMainPresenter.java
@@ -80,7 +80,7 @@ public class GopherMainPresenter implements Initializable {
     private Node rootNode;
     /** List of genome builds. Used by genomeChoiceBox */
     @FXML
-    private final ObservableList<String> genomeTranscriptomeList = FXCollections.observableArrayList("hg19", "hg38", "mm9", "mm10");
+    private final ObservableList<String> genomeTranscriptomeList = FXCollections.observableArrayList("hg19", "hg38", "mm9", "mm10", "xenTro9", "danRer10");
     /** List of Design approaches.  */
     @FXML
     private final ObservableList<String> approachList = FXCollections.observableArrayList("Simple", "Extended");
@@ -808,7 +808,7 @@ public class GopherMainPresenter implements Initializable {
      * @param build Name of genome build.
      */
     private void setGenomeBuild(String build) {
-        logger.info("Setting genome build to "+build);
+        logger.info("Setting genome build to "+ build);
         this.model.setGenomeBuild(build);
         this.transcriptDownloadPI.setProgress(0.0);
         this.alignabilityDownloadPI.setProgress(0.0);
@@ -1028,6 +1028,14 @@ public class GopherMainPresenter implements Initializable {
             case "mm10":
                 url = "ftp://ftp.jax.org/robinp/GOPHER/alignability_maps/mm10_50.m2.bedGraph.gz";
                 url2 = "http://hgdownload.cse.ucsc.edu/goldenPath/mm10/database/chromInfo.txt.gz";
+                break;
+            case "xenTro9":
+                url = "ftp://ftp.jax.org/robinp/GOPHER/alignability_maps/xenTro9_50.bedGraph.gz";
+                url2 = "http://hgdownload.cse.ucsc.edu/goldenPath/xenTro9/database/chromInfo.txt.gz";
+                break;
+            case "danRer10":
+                url = "ftp://ftp.jax.org/robinp/GOPHER/alignability_maps/danRer10_50.bedGraph.gz";
+                url2 = "http://hgdownload.cse.ucsc.edu/goldenPath/danRer10/database/chromInfo.txt.gz";
                 break;
             default:
                 //this.downloadAlignabilityLabel.setText(("No map available for " + genomeBuild));

--- a/src/main/java/gopher/gui/viewpointpanel/URLMaker.java
+++ b/src/main/java/gopher/gui/viewpointpanel/URLMaker.java
@@ -55,9 +55,15 @@ class URLMaker {
             case "mm9":
             url = String.format("%s&%s",url,getURLFragmentMm9());
             break;
-        case "mm10":
+            case "mm10":
             url = String.format("%s&%s",url,getURLFragmentMm10());
             break;
+            case "xenTro9":
+                url = String.format("%s&%s",url,getURLFragmentXenTro9());
+                break;
+            case "danRer10":
+                url = String.format("%s&%s",url,getURLFragmentDanRer10());
+                break;
             default:
                 // should never happen
                 logger.error("Unable to find URL for genome build "+genomebuild);
@@ -77,10 +83,15 @@ class URLMaker {
             url = String.format("%s&%s",url,getURLFragmentMm9());
         } else if (this.genomebuild.equals("mm10")) {
             url=String.format("%s&%s",url,getURLFragmentMm10());
+        }  else if (this.genomebuild.equals("xenTro9")) {
+            url = String.format("%s&%s",url,getURLFragmentXenTro9());
+        } else if (this.genomebuild.equals("danRer10")) {
+            url=String.format("%s&%s",url,getURLFragmentDanRer10());
         }
         logger.trace(String.format("URL for UCSC %s", url));
         return url;
     }
+
     /** These are the things to hide and show to get a nice hg19 image. */
     private String getURLFragmentHg19() {
         return "gc5Base=dense&snp150Common=hide&gtexGene=hide&dgvPlus=hide&pubs=hide&knownGene=hide&ncbiRefSeqView=pack&g=wgEncodeCrgMapabilityAlign50mer&i=wgEncodeCrgMapabilityAlign50mer";
@@ -90,6 +101,7 @@ class URLMaker {
     private String getURLFragmentHg38() {
         return "gc5Base=dense&snp150Common=hide&gtexGene=hide&dgvPlus=hide&pubs=hide&knownGene=hide&ncbiRefSeqView=pack&OmimAvSnp=hide";
     }
+
     /** These are the things to hide and show to get a nice mm9 image. */
     private String getURLFragmentMm9() {
         return "gc5Base=dense&knownGene=hide&ncbiRefSeqView=pack&stsMapMouseNew=hide&xenoRefGene=hide&ensGene=hide&pubs=hide&intronEst=hide&snp128=hide&oreganno=full&wgEncodeCrgMapabilityAlign50mer=full";
@@ -98,6 +110,16 @@ class URLMaker {
     /** These are the things to hide and show to get a nice mm9 image. */
     private String getURLFragmentMm10() {
         return "gc5Base=dense&knownGene=hide&ncbiRefSeqView=pack&stsMapMouseNew=hide&xenoRefGene=hide&ensGene=hide&pubs=hide&intronEst=hide&snp142Common=hide&oreganno=full";
+    }
+
+    /** These are the things to hide and show to get a nice xenTro9 image. */
+    private String getURLFragmentXenTro9() {
+        return "gc5BaseBw=dense&rmsk=dense&cons11way=hide";
+    }
+
+    /** These are the things to hide and show to get a nice danRer10 image. */
+    private String getURLFragmentDanRer10() {
+        return "gc5BaseBw=dense&rmsk=dense&cons11way=hide";
     }
 
 

--- a/src/main/java/gopher/io/Downloader.java
+++ b/src/main/java/gopher/io/Downloader.java
@@ -66,7 +66,7 @@ public class Downloader extends Task<Void> {
 
     protected void setLocalFilePath (String bname) {
         this.localFilePath = new File(this.localDir + File.separator + bname);
-        logger.debug("setLocalFilepath for download to: "+localFilePath);
+        logger.debug("setLocalFilepath for download to: " + localFilePath);
     }
 
     /**
@@ -93,8 +93,8 @@ public class Downloader extends Task<Void> {
             URL url = new URL(urlstring);
             URLConnection urlc = url.openConnection();
             reader = urlc.getInputStream();
-            logger.trace("URL host: "+ url.getHost() + "\n reader available="+reader.available());
-            logger.trace("LocalFilePath: "+localFilePath);
+            logger.trace("URL host: "+ url.getHost() + "\n reader available=" + reader.available());
+            logger.trace("LocalFilePath: " + localFilePath);
             writer = new FileOutputStream(localFilePath);
             byte[] buffer = new byte[153600];
             int totalBytesRead = 0;
@@ -113,7 +113,7 @@ public class Downloader extends Task<Void> {
                     threshold += block;
                 }
             }
-            logger.info("Successful download from "+urlstring+": " + (Integer.toString(totalBytesRead)) + "(" + size + ") bytes read.");
+            logger.info("Successful download from " + urlstring + ": " + (Integer.toString(totalBytesRead)) + "(" + size + ") bytes read.");
             writer.close();
         } catch (MalformedURLException e) {
             updateProgress(0.00);

--- a/src/main/java/gopher/io/GenomeDownloader.java
+++ b/src/main/java/gopher/io/GenomeDownloader.java
@@ -1,16 +1,12 @@
 package gopher.io;
 
+import gopher.model.genome.*;
 import javafx.scene.control.ProgressIndicator;
 import org.apache.log4j.Logger;
 import gopher.exception.DownloadFileNotFoundException;
 
 import gopher.gui.popupdialog.PopupFactory;
 import gopher.model.DataSource;
-import gopher.model.genome.Genome;
-import gopher.model.genome.HumanHg19;
-import gopher.model.genome.HumanHg38;
-import gopher.model.genome.MouseMm9;
-import gopher.model.genome.MouseMm10;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -29,10 +25,9 @@ public class GenomeDownloader {
     private boolean successful=false;
 
 
-
     public GenomeDownloader(String build) {
         this.genomebuild=build;
-        logger.debug("Constructor of GenomeDownloader, build="+build);
+        logger.debug("Constructor of GenomeDownloader, build=" + build);
         try {
             this.url=getGenomeURL(build);
             this.genome=getGenome(build);
@@ -59,8 +54,8 @@ public class GenomeDownloader {
      */
     public void downloadGenome(String directory, String basename, ProgressIndicator pi) {
         Downloader downloadTask = new Downloader(directory, this.url, basename, pi);
-        logger.trace(String.format("Starting download of %s to %s",directory,url));
-        downloadTask.setOnSucceeded(e -> logger.trace("Finished downloading genome file to "+directory));
+        logger.trace(String.format("Starting download of %s to %s",url,directory));
+        downloadTask.setOnSucceeded(e -> logger.trace("Finished downloading genome file to " + directory));
         downloadTask.setOnFailed(eh -> {
             StringWriter sw = new StringWriter();
             PrintWriter pw = new PrintWriter(sw);
@@ -90,6 +85,10 @@ public class GenomeDownloader {
             return DataSource.createUCSCmm9().getGenomeURL();
         } else if (gb.equals("mm10")) {
             return DataSource.createUCSCmm10().getGenomeURL();
+        } else if (gb.equals("xenTro9")) {
+            return DataSource.createUCSCxenTro9().getGenomeURL();
+        } else if (gb.equals("danRer10")) {
+            return DataSource.createUCSCdanRer10().getGenomeURL();
         } else {
             throw new DownloadFileNotFoundException(String.format("Attempt to get URL for unknown genome build: %s.", gb));
         }
@@ -105,6 +104,10 @@ public class GenomeDownloader {
             return new MouseMm9();
         } else if (genomebuild.equals("mm10")) {
             return new MouseMm10();
+        } else if (genomebuild.equals("xenTro9")) {
+            return new FrogXenTro9();
+        } else if (genomebuild.equals("danRer10")) {
+            return new FishDanRer10();
         } else {
             throw new DownloadFileNotFoundException(String.format("Attempt to get Genome object for unknown genome build: %s.", genomebuild));
         }

--- a/src/main/java/gopher/io/RefGeneDownloader.java
+++ b/src/main/java/gopher/io/RefGeneDownloader.java
@@ -15,6 +15,8 @@ public class RefGeneDownloader {
     final private static String hg38="http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/refGene.txt.gz";
     final private static String mm9="http://hgdownload.soe.ucsc.edu/goldenPath/mm9/database/refGene.txt.gz";
     final private static String mm10="http://hgdownload.soe.ucsc.edu/goldenPath/mm10/database/refGene.txt.gz";
+    final private static String xenTro9="http://hgdownload.soe.ucsc.edu/goldenPath/xenTro9/database/refGene.txt.gz";
+    final private static String danRer10="http://hgdownload.soe.ucsc.edu/goldenPath/danRer10/database/refGene.txt.gz";
 
     private String genome=null;
 
@@ -33,6 +35,10 @@ public class RefGeneDownloader {
             url=mm9;
         else if (this.genome.equals("mm10"))
             url=mm10;
+        else if (this.genome.equals("xenTro9"))
+            url=xenTro9;
+        else if (this.genome.equals("danRer10"))
+            url=danRer10;
         else
             throw new DownloadFileNotFoundException("Could not identify download URL for genome: "+genome);
         return url;

--- a/src/main/java/gopher/model/DataSource.java
+++ b/src/main/java/gopher/model/DataSource.java
@@ -32,11 +32,13 @@ public class DataSource {
 
     private static final String UCSChg38url = "http://hgdownload.soe.ucsc.edu/goldenPath/hg38/bigZips/hg38.chromFa.tar.gz";
 
-
     private static final String UCSCmm9url = "http://hgdownload.soe.ucsc.edu/goldenPath/mm9/bigZips/chromFa.tar.gz";
 
-
     private static final String UCSCmm10url = "http://hgdownload.soe.ucsc.edu/goldenPath/mm10/bigZips/chromFa.tar.gz";
+
+    private static final String UCSCxenTro9url = "http://hgdownload.soe.ucsc.edu/goldenPath/xenTro9/bigZips/xenTro9.fa.gz";
+
+    private static final String UCSCdanRer10url = "http://hgdownload.soe.ucsc.edu/goldenPath/danRer10/bigZips/danRer10.fa.gz";
 
 
     private DataSource(){
@@ -69,6 +71,20 @@ public class DataSource {
         DataSource ds = new DataSource();
         ds.genomeName="UCSC-mm10";
         ds.genomeURL=UCSCmm10url;
+        return ds;
+    }
+
+    public static DataSource createUCSCxenTro9() {
+        DataSource ds = new DataSource();
+        ds.genomeName="UCSC-xenTro9";
+        ds.genomeURL=UCSCxenTro9url;
+        return ds;
+    }
+
+    public static DataSource createUCSCdanRer10() {
+        DataSource ds = new DataSource();
+        ds.genomeName="UCSC-danRer10";
+        ds.genomeURL=UCSCdanRer10url;
         return ds;
     }
 }

--- a/src/main/java/gopher/model/Model.java
+++ b/src/main/java/gopher/model/Model.java
@@ -131,6 +131,12 @@ public class Model implements Serializable {
             case "mm10":
                 this.genome = new MouseMm10();
                 break;
+            case "xenTro9":
+                this.genome = new FrogXenTro9();
+                break;
+            case "danRer10":
+                this.genome = new FishDanRer10();
+                break;
             default:
                 PopupFactory.displayError("setGenomeBuild error", String.format("genome build %s not implemented", newDatabase));
         }

--- a/src/main/java/gopher/model/genome/FishDanRer10.java
+++ b/src/main/java/gopher/model/genome/FishDanRer10.java
@@ -1,0 +1,45 @@
+package gopher.model.genome;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * Created by hansep on 11/27/17.
+ */
+public class FishDanRer10 extends Genome implements Serializable {
+    /** serialization version ID */
+    static final long serialVersionUID = 3L;
+
+    private static final String genomeBasename="danRer10.chromFa.tar.gz";
+
+    private static final String[] chromosomes = {"chr1", "chr2", "chr3", "chr4", "chr5", "chr6", "chr7", "chr8", "chr9", "chr10", "chr11", "chr12", "chr13", "chr14", "chr15", "chr16", "chr17", "chr18", "chr19", "chr20", "chr21", "chr22", "chr23", "chr24", "chr25"};
+
+
+    public FishDanRer10(String directoryPath) {
+        super(directoryPath);
+        init();
+    }
+
+    public FishDanRer10() {
+        super();
+    }
+
+    @Override
+    protected void init() {
+        Arrays.stream(chromosomes).forEach(s -> {
+            valid.add(s);
+            chromosomeFileNames.add(String.format("%s.fa",s));
+        });
+    }
+
+    @Override
+    public String getGenomeBuild() {
+        return "danRer10";
+    }
+    @Override public String getGenomeFastaName(){return "danRer10.fa"; }
+
+    @Override
+    public String getGenomeBasename(){return genomeBasename;}
+    @Override
+    public  int getNumberOfCanonicalChromosomes() { return chromosomes.length; }
+}

--- a/src/main/java/gopher/model/genome/FrogXenTro9.java
+++ b/src/main/java/gopher/model/genome/FrogXenTro9.java
@@ -1,0 +1,46 @@
+package gopher.model.genome;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * Created by hansep on 11/27/17.
+ */
+public class FrogXenTro9 extends Genome implements Serializable {
+    /** serialization version ID */
+    static final long serialVersionUID = 3L;
+
+    private static final String genomeBasename="xenTro9.chromFa.tar.gz";
+
+    private static final String[] chromosomes = {"chr1", "chr2", "chr3", "chr4", "chr5", "chr6", "chr7", "chr8", "chr9",
+            "chr10"};
+
+
+    public FrogXenTro9(String directoryPath) {
+        super(directoryPath);
+        init();
+    }
+
+    public FrogXenTro9() {
+        super();
+    }
+
+    @Override
+    protected void init() {
+        Arrays.stream(chromosomes).forEach(s -> {
+            valid.add(s);
+            chromosomeFileNames.add(String.format("%s.fa",s));
+        });
+    }
+
+    @Override
+    public String getGenomeBuild() {
+        return "xenTro9";
+    }
+    @Override public String getGenomeFastaName(){return "xenTro9.fa"; }
+
+    @Override
+    public String getGenomeBasename(){return genomeBasename;}
+    @Override
+    public  int getNumberOfCanonicalChromosomes() { return chromosomes.length; }
+}

--- a/src/main/java/gopher/model/genome/Genome.java
+++ b/src/main/java/gopher/model/genome/Genome.java
@@ -25,7 +25,7 @@ public abstract class Genome implements Serializable {
     protected static final String localFilename = "chromFa.tar.gz";
     /** The valid chromosomes for the current genome build. (will be initialized from the subclasses).*/
     protected Set<String> valid=null;
-    /** Set of base chromosome file names for canonical chromosomes. For instnace, "chr1.fa", but not "chr1random12432.fa" .*/
+    /** Set of base chromosome file names for canonical chromosomes. For instance, "chr1.fa", but not "chr1random12432.fa" .*/
     protected Set<String> chromosomeFileNames;
     /** This is the name of the file we download from UCSC for any of the genomes. */
     private static final String DEFAULT_GENOME_BASENAME = "chromFa.tar.gz";

--- a/src/main/resources/data/enzymelist.tab
+++ b/src/main/resources/data/enzymelist.tab
@@ -1,6 +1,10 @@
 #name   site
 HindIII A^AGCTT
 DpnII ^GATC
+DpnIIcA ^GAATC
+DpnIIcC ^GACTC
+DpnIIcG ^GAGTC
+DpnIIcT ^GATTC
 NlaIII  CATG^
 AatII   GACGT^C
 ApaI	GGGCC^C


### PR DESCRIPTION
I added the genome builds xenTro9 and danRer10. Alignability maps were created using GEMTools and uploaded to:

ftp://ftp.jax.org/robinp/GOPHER/alignability_maps/

I designed viewpoints for all protein-coding genes and no error occurred.

I checked some viewpoints and the results look good, especially the placement of probes seems to e consistent with the alignability maps. This is one example for xenTro9:

![image](https://user-images.githubusercontent.com/10495485/60255068-526c6b00-98cf-11e9-9e79-e747ac828b53.png)

And this is one example for danRer10:

![image](https://user-images.githubusercontent.com/10495485/60255583-564cbd00-98d0-11e9-8d63-6e8fc130bad7.png)

The URLs for the UCSC browser could be improved. But this can also be done upon request.

